### PR TITLE
7 no virtual tile edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 *.opendb
 .vs/
 GeneratedFiles/
+qt/tileedit/resources/
 x64/

--- a/qt/tileedit/tileedit/elevtile.h
+++ b/qt/tileedit/tileedit/elevtile.h
@@ -16,6 +16,8 @@ struct ElevData {
 	ElevData();
 	ElevData(const ElevData &edata);
 	ElevData &operator=(const ElevData &edata);
+	double nodeValue(int ix, int iy) const;
+	void setNodeValue(int ix, int iy, double v);
 	ElevData SubTile(const std::pair<DWORD, DWORD> &xrange, const std::pair<DWORD, DWORD> &yrange);
 };
 
@@ -41,7 +43,7 @@ class ElevTile : public Tile {
 
 public:
 	ElevTile(const ElevTile &etile);
-	static ElevTile *Load(const std::string &root, int lvl, int ilat, int ilng, ElevDisplayParam &elevDisplayParam, const Cmap *cm = 0);
+	static ElevTile *Load(int lvl, int ilat, int ilng, ElevDisplayParam &elevDisplayParam, const Cmap *cm = 0);
 	static void setTreeMgr(const ZTreeMgr *mgr, const ZTreeMgr *modMgr = 0);
 	const std::string Layer() const { return std::string("Elev"); }
 	double nodeElevation(int ndx, int ndy);
@@ -51,18 +53,24 @@ public:
 	void displayParamChanged();
 	bool isModified() const { return m_modified; }
 	void dataChanged(int exmin = -1, int exmax = -1, int eymin = -1, int eymax = -1);
-	void Save(const std::string &root);
-	void SaveMod(const std::string &root);
-	void MatchNeighbourTiles(const std::string &root);
-	bool MatchParentTile(const std::string &root, int minlvl) const;
+	void Save();
+	void SaveMod();
+	void MatchNeighbourTiles();
+	bool MatchParentTile(int minlvl) const;
+
+	/**
+	 * \brief Interpolate the tile to the next resolution level
+	 */
+	ElevTileBlock Prolong();
+
 	void setWaterMask(const MaskTile *mtile);
 
 protected:
 	ElevTile(int lvl, int ilat, int ilng, ElevDisplayParam &elevDisplayParam);
 	bool Load(const std::string &root);
-	void LoadSubset(const std::string &root);
-	void LoadData(ElevData &edata, const std::string &root, int lvl, int ilat, int ilng);
-	void LoadModData(ElevData &edata, const std::string &root, int lvl, int ilat, int ilng);
+	void LoadSubset();
+	void LoadData(ElevData &edata, int lvl, int ilat, int ilng);
+	void LoadModData(ElevData &edata, int lvl, int ilat, int ilng);
 	void ExtractImage(int exmin = -1, int exmax = -1, int eymin = -1, int eymax = -1);
 
 private:

--- a/qt/tileedit/tileedit/elevtile.h
+++ b/qt/tileedit/tileedit/elevtile.h
@@ -44,6 +44,7 @@ class ElevTile : public Tile {
 public:
 	ElevTile(const ElevTile &etile);
 	static ElevTile *Load(int lvl, int ilat, int ilng, ElevDisplayParam &elevDisplayParam, const Cmap *cm = 0);
+	static ElevTile *InterpolateFromAncestor(int lvl, int ilat, int ilng, ElevDisplayParam &elevDisplayParam, const Cmap *cm = 0);
 	static void setTreeMgr(const ZTreeMgr *mgr, const ZTreeMgr *modMgr = 0);
 	const std::string Layer() const { return std::string("Elev"); }
 	double nodeElevation(int ndx, int ndy);
@@ -67,7 +68,8 @@ public:
 
 protected:
 	ElevTile(int lvl, int ilat, int ilng, ElevDisplayParam &elevDisplayParam);
-	bool Load(const std::string &root);
+	bool Load(bool allowAncestorSubset = true);
+	bool InterpolateFromAncestor();
 	void LoadSubset();
 	void LoadData(ElevData &edata, int lvl, int ilat, int ilng);
 	void LoadModData(ElevData &edata, int lvl, int ilat, int ilng);

--- a/qt/tileedit/tileedit/tile.h
+++ b/qt/tileedit/tileedit/tile.h
@@ -25,6 +25,7 @@ public:
 	DWORD pixelColour(int px, int py) const;
 	virtual const std::string Layer() const = 0;
 
+	static void setRoot(const std::string &root);
 	static void setOpenMode(int mode);
 
 protected:
@@ -38,6 +39,7 @@ protected:
     std::pair<DWORD, DWORD> lng_subrange;
     Image img;
 
+	static std::string s_root;
 	static int s_openMode;
 };
 
@@ -47,15 +49,15 @@ public:
 	DXT1Tile(int lvl, int ilat, int ilng);
 
 protected:
-	virtual void LoadDXT1(const std::string &root, const ZTreeMgr *mgr = 0);
-	void LoadSubset(const std::string &root, DXT1Tile *tile, const ZTreeMgr *mgr = 0);
-	void LoadImage(Image &im, const std::string &root, int lvl, int ilat, int ilng, const ZTreeMgr *mgr);
+	virtual void LoadDXT1(const ZTreeMgr *mgr = 0);
+	void LoadSubset(DXT1Tile *tile, const ZTreeMgr *mgr = 0);
+	void LoadImage(Image &im, int lvl, int ilat, int ilng, const ZTreeMgr *mgr);
 };
 
 class SurfTile: public DXT1Tile
 {
 public:
-    static SurfTile *Load(const std::string &root, int lvl, int ilat, int ilng);
+    static SurfTile *Load(int lvl, int ilat, int ilng);
 	static void setTreeMgr(const ZTreeMgr *mgr);
 	const std::string Layer() const { return std::string("Surf"); }
 
@@ -78,7 +80,7 @@ protected:
 class MaskTile : public DXT1Tile
 {
 public:
-	static std::pair<MaskTile*, NightlightTile*> Load(const std::string &root, int lvl, int ilat, int ilng);
+	static std::pair<MaskTile*, NightlightTile*> Load(int lvl, int ilat, int ilng);
 	static void setTreeMgr(const ZTreeMgr *mgr);
 	const std::string Layer() const { return std::string("Mask"); }
 

--- a/qt/tileedit/tileedit/tileblock.cpp
+++ b/qt/tileedit/tileedit/tileblock.cpp
@@ -24,7 +24,7 @@ ElevTileBlock::ElevTileBlock(int lvl, int ilat0, int ilat1, int ilng0, int ilng1
 	m_edata.data.resize(m_edata.width * m_edata.height);
 }
 
-ElevTileBlock *ElevTileBlock::Load(const std::string &root, int lvl, int ilat0, int ilat1, int ilng0, int ilng1, ElevDisplayParam &elevDisplayParam)
+ElevTileBlock *ElevTileBlock::Load(int lvl, int ilat0, int ilat1, int ilng0, int ilng1, ElevDisplayParam &elevDisplayParam)
 {
 	ElevTileBlock *tileblock = new ElevTileBlock(lvl, ilat0, ilat1, ilng0, ilng1);
 	int nlat = tileblock->nLat();
@@ -35,7 +35,7 @@ ElevTileBlock *ElevTileBlock::Load(const std::string &root, int lvl, int ilat0, 
 			int ilngn = ilng;
 			while (ilngn < 0) ilngn += nlng;
 			while (ilngn >= nlng) ilngn -= nlng;
-			ElevTile *tile = ElevTile::Load(root, lvl, ilat, ilngn, elevDisplayParam);
+			ElevTile *tile = ElevTile::Load(lvl, ilat, ilngn, elevDisplayParam);
 			tileblock->setTile(ilat, ilng, tile);
 			delete tile;
 		}

--- a/qt/tileedit/tileedit/tileblock.cpp
+++ b/qt/tileedit/tileedit/tileblock.cpp
@@ -1,4 +1,5 @@
 #include "tileblock.h"
+#include <algorithm>
 
 TileBlock::TileBlock(int lvl, int ilat0, int ilat1, int ilng0, int ilng1)
 {
@@ -98,5 +99,10 @@ bool ElevTileBlock::getTile(int ilat, int ilng, Tile *tile) const
 				m_edata.data[(block_y0 + y) * m_edata.width + (block_x0 + x)];
 		}
 	}
+
+	edata.dmin = *std::min_element(edata.data.begin(), edata.data.end());
+	edata.dmax = *std::max_element(edata.data.begin(), edata.data.end());
+	etile->dataChanged();
+
 	return true;
 }

--- a/qt/tileedit/tileedit/tileblock.h
+++ b/qt/tileedit/tileedit/tileblock.h
@@ -30,7 +30,7 @@ protected:
 class ElevTileBlock : public TileBlock
 {
 public:
-	static ElevTileBlock *Load(const std::string &root, int lvl, int ilat0, int ilat1, int ilng0, int ilng1, ElevDisplayParam &elevDisplayParam);
+	static ElevTileBlock *Load(int lvl, int ilat0, int ilat1, int ilng0, int ilng1, ElevDisplayParam &elevDisplayParam);
 	ElevTileBlock(int lvl, int ilat0, int ilat1, int ilng0, int ilng1);
 	bool setTile(int ilat, int ilng, const Tile *tile);
 	bool getTile(int ilat, int ilng, Tile *tile) const;

--- a/qt/tileedit/tileedit/tileedit.cpp
+++ b/qt/tileedit/tileedit/tileedit.cpp
@@ -355,9 +355,20 @@ void tileedit::onActionButtonClicked(int id)
 		}
 		if (m_etile->subLevel() < m_etile->Level()) {
 			QMessageBox mbox(QMessageBox::Warning, "tileedit", "This elevation tile does not exist - the image you see has been synthesized from a subsection of an ancestor.\n\nBefore this tile can be edited it must be created. Do you want to create it now?", QMessageBox::Yes | QMessageBox::No);
-			mbox.exec();
-			ui->btnActionNavigate->setChecked(true);
-			return; // don't allow editing virtual tiles
+			int res = mbox.exec();
+			if (res == QMessageBox::Yes) {
+				ElevTile *tile = ElevTile::InterpolateFromAncestor(m_lvl, m_ilat, m_ilng, m_elevDisplayParam);
+				if (tile) {
+					tile->dataChanged();
+					tile->Save();
+					delete tile;
+					loadTile(m_lvl, m_ilat, m_ilng);
+				}
+			}
+			else {
+				ui->btnActionNavigate->setChecked(true);
+				return; // don't allow editing virtual tiles
+			}
 		}
 	}
 

--- a/qt/tileedit/tileedit/tileedit.h
+++ b/qt/tileedit/tileedit/tileedit.h
@@ -107,7 +107,7 @@ private:
 		ELEVEDIT_ERASE
 	} m_elevEditMode;
 
-    std::string rootDir;
+    //std::string rootDir;
     int m_lvl;
     int m_ilat;
     int m_ilng;


### PR DESCRIPTION
Edits of synthesized elevation tiles are now disabled. Instead, the user is offered to generate the tile before editing. This creates a new tile by recursively interpolating a parent subsection, and writing the tile to the disk cache.

Things still to be implemented:
- user should be offered to create not only that tile, but also any missing ancestor tiles
- currently, the new tile is only written to the Elev layer, from ancestor data that may have merged Elev and Elev_mod data. Instead, the Elev and Elev_mod data should be kept separate and written to both layers, if any mod data are present.
- The new tile should not only be interpolated up from an ancestor, but also interpolated down from any existing descendants.