### PR TITLE
24 surface import from png

### DIFF
--- a/qt/tileedit/extern/fastdxt/FastDXTImageProcessor.cpp
+++ b/qt/tileedit/extern/fastdxt/FastDXTImageProcessor.cpp
@@ -1,0 +1,104 @@
+/* -*-c++-*- */
+/* osgEarth - Geospatial SDK for OpenSceneGraph
+* Copyright 2008-2013 Pelican Mapping
+* http://osgearth.org
+*
+* osgEarth is free software; you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#include <osg/Texture>
+#include <osgDB/Registry>
+#include <osg/Notify>
+#include <osgEarth/ImageUtils>
+#include <stdlib.h>
+#include "libdxt.h"
+#include <string.h>
+
+class FastDXTProcessor : public osgDB::ImageProcessor
+{
+public:
+    virtual void compress(osg::Image& image, osg::Texture::InternalFormatMode compressedFormat, bool generateMipMap, bool resizeToPowerOfTwo, CompressionMethod method, CompressionQuality quality)
+    {
+        //Resize the image to the nearest power of two
+        if (!osgEarth::ImageUtils::isPowerOfTwo( &image ))
+        {
+            unsigned int s = osg::Image::computeNearestPowerOfTwo( image.s() );
+            unsigned int t = osg::Image::computeNearestPowerOfTwo( image.t() );
+            image.scaleImage(s, t, image.r());
+        }
+
+        osg::Image* sourceImage = &image;
+
+        //FastDXT only works on RGBA imagery so we must convert it
+        osg::ref_ptr< osg::Image > rgba;
+        if (image.getPixelFormat() != GL_RGBA)
+        {
+            osg::Timer_t start = osg::Timer::instance()->tick();
+            rgba = osgEarth::ImageUtils::convertToRGBA8( &image );
+            osg::Timer_t end = osg::Timer::instance()->tick();
+            OE_DEBUG << "conversion to rgba took" << osg::Timer::instance()->delta_m(start, end) << std::endl;
+            sourceImage = rgba.get();
+        }
+
+        int format;
+        GLint pixelFormat;
+        switch (compressedFormat)
+        {
+        case osg::Texture::USE_S3TC_DXT1_COMPRESSION:
+            format = FORMAT_DXT1;
+            pixelFormat = GL_COMPRESSED_RGB_S3TC_DXT1_EXT;
+            OE_DEBUG << "FastDXT using dxt1 format" << std::endl;
+            break;
+        case osg::Texture::USE_S3TC_DXT5_COMPRESSION:
+            format = FORMAT_DXT5;
+            pixelFormat = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+            OE_DEBUG << "FastDXT dxt5 format" << std::endl;
+            break;
+        default:
+            OSG_WARN << "Unhandled compressed format" << compressedFormat << std::endl;
+            return;
+            break;
+        }
+
+        //Copy over the source data to an array
+        unsigned char *in = 0;
+        in = (unsigned char*)memalign(16, sourceImage->getTotalSizeInBytes());
+        memcpy(in, sourceImage->data(0,0), sourceImage->getTotalSizeInBytes());
+
+
+
+        //Allocate memory for the output
+        unsigned char* out = (unsigned char*)memalign(16, image.s()*image.t()*4);
+        memset(out, 0, image.s()*image.t()*4);
+
+        osg::Timer_t start = osg::Timer::instance()->tick();
+        int outputBytes = CompressDXT(in, out, sourceImage->s(), sourceImage->t(), format);
+        osg::Timer_t end = osg::Timer::instance()->tick();
+        OE_DEBUG << "compression took" << osg::Timer::instance()->delta_m(start, end) << std::endl;
+
+        //Allocate and copy over the output data to the correct size array.
+        unsigned char* data = (unsigned char*)malloc(outputBytes);
+        memcpy(data, out, outputBytes);
+        memfree(out);
+        memfree(in);
+        image.setImage(image.s(), image.t(), image.r(), pixelFormat, pixelFormat, GL_UNSIGNED_BYTE, data, osg::Image::USE_MALLOC_FREE);
+    }
+
+    virtual void generateMipMap(osg::Image& image, bool resizeToPowerOfTwo, CompressionMethod method)
+    {
+        OSG_WARN << "FastDXT: generateMipMap not implemented" << std::endl;
+    }
+};
+
+REGISTER_OSGIMAGEPROCESSOR(fastdxt, FastDXTProcessor)

--- a/qt/tileedit/extern/fastdxt/dxt.cpp
+++ b/qt/tileedit/extern/fastdxt/dxt.cpp
@@ -1,0 +1,542 @@
+// From:
+//    Real-Time DXT Compression
+//    May 20th 2006 J.M.P. van Waveren
+//    (c) 2006, Id Software, Inc.
+
+#include "dxt.h"
+#include "util.h"
+
+
+#define DXT_INTR 1
+
+void ExtractBlock( const byte *inPtr, int width, byte *colorBlock );
+void ExtractBlock_Intrinsics( const byte *inPtr, int width, byte *colorBlock );
+
+void GetMinMaxColors( const byte *colorBlock, byte *minColor, byte *maxColor );
+void GetMinMaxColorsByLuminance( const byte *colorBlock, byte *minColor, byte *maxColor );
+void GetMinMaxColorsByBBox( const byte *colorBlock, byte *minColor, byte *maxColor );
+void GetMinMaxColors_Intrinsics( const byte *colorBlock, byte *minColor, byte *maxColor );
+
+// for DXT5
+void GetMinMaxColorsAlpha(  byte *colorBlock, byte *minColor, byte *maxColor );
+
+
+word ColorTo565( const byte *color );
+
+void EmitByte( byte b, byte*& );
+void EmitWord( word s, byte*& );
+void EmitDoubleWord( dword i, byte*& );
+
+void EmitColorIndices( const byte *colorBlock, const byte *minColor, const byte *maxColor, byte *&outData );
+void EmitColorIndicesFast( const byte *colorBlock, const byte *minColor, const byte *maxColor, byte *&outData );
+void EmitColorIndices_Intrinsics( const byte *colorBlock, const byte *minColor, const byte *maxColor, byte *&outData);
+
+// Emit indices for DXT5
+void EmitAlphaIndices( const byte *colorBlock, const byte minAlpha, const byte maxAlpha, byte *&outData);
+void EmitAlphaIndicesFast( const byte *colorBlock, const byte minAlpha, const byte maxAlpha, byte *&outData);
+void EmitAlphaIndices_Intrinsics( const byte *colorBlock, const byte minAlpha, const byte maxAlpha, byte *&outData);
+
+
+void CompressImageDXT1( const byte *inBuf, byte *outBuf,
+			int width, int height, int &outputBytes )
+{
+  ALIGN16( byte *outData );
+  ALIGN16( byte block[64] );
+  ALIGN16( byte minColor[4] );
+  ALIGN16( byte maxColor[4] );
+
+  outData = outBuf;
+  for ( int j = 0; j < height; j += 4, inBuf += width * 4*4 ) {
+    for ( int i = 0; i < width; i += 4 ) {
+
+#if defined(DXT_INTR)
+	ExtractBlock_Intrinsics( inBuf + i * 4, width, block );
+#else
+	ExtractBlock( inBuf + i * 4, width, block );
+#endif
+
+#if defined(DXT_INTR)
+      GetMinMaxColors_Intrinsics( block, minColor, maxColor );
+#else
+      GetMinMaxColorsByBBox( block, minColor, maxColor );
+#endif
+
+      EmitWord( ColorTo565( maxColor ), outData );
+      EmitWord( ColorTo565( minColor ), outData );
+
+#if defined(DXT_INTR)
+      EmitColorIndices_Intrinsics( block, minColor, maxColor, outData );
+#else
+      EmitColorIndicesFast( block, minColor, maxColor, outData );
+#endif
+    }
+  }
+  outputBytes = (int) ( outData - outBuf );
+}
+
+void RGBAtoYCoCg(const byte *inBuf, byte *outBuf, int width, int height)
+{
+  for ( int j = 0; j < width*height; j++ ) {
+    byte R = inBuf[j*4+0];
+    byte G = inBuf[j*4+1];
+    byte B = inBuf[j*4+2];
+    byte A = inBuf[j*4+3];
+    int Co = R-B;
+    int t = B + (Co/2);
+    int Cg = G-t;
+    int Y = t + (Cg/2);
+
+    Co += 128;
+    Cg += 96;
+
+//     if (Co < 0 || Co > 255)
+//       fprintf(stderr, "Co: %d\n", Co);
+//     if (Cg < 0 || Cg > 255)
+//       fprintf(stderr, "Cg: %d\n", Cg);
+//     if ( Y < 0 ||  Y > 255)
+//       fprintf(stderr, "Y: %d\n", Y);
+
+    if (Co < 0)   Co=0;
+    if (Co > 255) Co=255;
+    if (Cg < 0)   Cg=0;
+    if (Cg > 255) Cg=255;
+
+    outBuf[j*4+0] = Co;
+    outBuf[j*4+1] = Cg;
+    outBuf[j*4+2] = 0;
+    outBuf[j*4+3] = Y;
+  }
+}
+
+void CompressImageDXT5YCoCg( const byte *inBuf, byte *outBuf, int width, int height,
+			     int &outputBytes )
+{
+  byte *tmpBuf;
+  tmpBuf = (byte*)memalign(16, width*height*4);
+  memset(tmpBuf, 0, width*height*4);
+  RGBAtoYCoCg(inBuf, tmpBuf, width, height);
+  CompressImageDXT5(tmpBuf, outBuf, width, height, outputBytes);
+  memfree(tmpBuf);
+}
+
+
+void CompressImageDXT5( const byte *inBuf, byte *outBuf, int width, int height,
+			int &outputBytes )
+{
+  ALIGN16( byte *outData );
+  
+  ALIGN16( byte block[64] );
+  ALIGN16( byte minColor[4] );
+  ALIGN16( byte maxColor[4] );
+  
+  outData = outBuf;
+  for ( int j = 0; j < height; j += 4, inBuf += width * 4*4 ) {
+    for ( int i = 0; i < width; i += 4 ) {
+      
+#if defined(DXT_INTR)
+      ExtractBlock_Intrinsics( inBuf + i * 4, width, block );
+#else
+      ExtractBlock( inBuf + i * 4, width, block );
+#endif
+      
+#if defined(DXT_INTR)
+      GetMinMaxColors_Intrinsics( block, minColor, maxColor );
+#else
+      GetMinMaxColorsAlpha( block, minColor, maxColor );
+#endif
+      
+      EmitByte( maxColor[3], outData);
+      EmitByte( minColor[3], outData);
+      
+#if defined(DXT_INTR)
+	  // Not Yet Implemented
+      //EmitAlphaIndices_Intrinsics( block, minColor[3], maxColor[3], outData );
+
+      EmitAlphaIndicesFast( block, minColor[3], maxColor[3], outData );
+#else
+      EmitAlphaIndicesFast( block, minColor[3], maxColor[3], outData );
+#endif
+      
+      EmitWord( ColorTo565( maxColor ), outData);
+      EmitWord( ColorTo565( minColor ), outData);
+      
+#if defined(DXT_INTR)
+      EmitColorIndices_Intrinsics( block, minColor, maxColor, outData );
+#else
+      EmitColorIndicesFast( block, minColor, maxColor, outData );
+#endif
+    }
+  }
+  outputBytes = int( outData - outBuf );
+}
+
+
+
+
+void ExtractBlock( const byte *inPtr, int width, byte *colorBlock )
+{
+  for ( int j = 0; j < 4; j++ ) {
+    memcpy( &colorBlock[j*4*4], inPtr, 4*4 );
+    inPtr += width * 4;    
+  }
+}
+
+word ColorTo565( const byte *color )
+{
+  return ( ( color[ 0 ] >> 3 ) << 11 ) |
+         ( ( color[ 1 ] >> 2 ) <<  5 ) |
+         (   color[ 2 ] >> 3 );
+}
+
+void EmitByte( byte b, byte *&outData)
+{
+  outData[0] = b;
+  outData += 1;
+}
+
+void EmitWord( word s, byte *&outData)
+{
+  outData[0] = ( s >> 0 ) & 255;
+  outData[1] = ( s >> 8 ) & 255;
+  outData += 2;
+}
+
+void EmitDoubleWord( dword i, byte *&outData)
+{
+  outData[0] = ( i >> 0 ) & 255;
+  outData[1] = ( i >> 8 ) & 255;
+  outData[2] = ( i >> 16 ) & 255;
+  outData[3] = ( i >> 24 ) & 255;
+  outData += 4;
+}
+
+
+int ColorDistance( const byte *c1, const byte *c2 )
+{
+  return ( ( c1[0] - c2[0] ) * ( c1[0] - c2[0] ) ) +
+    ( ( c1[1] - c2[1] ) * ( c1[1] - c2[1] ) ) +
+    ( ( c1[2] - c2[2] ) * ( c1[2] - c2[2] ) );
+}
+
+void SwapColors( byte *c1, byte *c2 )
+{
+  byte tm[3];
+  memcpy( tm, c1, 3 );
+  memcpy( c1, c2, 3 );
+  memcpy( c2, tm, 3 );
+}
+
+void GetMinMaxColors( const byte *colorBlock, byte *minColor, byte *maxColor )
+{
+  int maxDistance = -1;
+  for ( int i = 0; i < 64 - 4; i += 4 ) {
+    for ( int j = i + 4; j < 64; j += 4 ) {
+      int distance = ColorDistance( &colorBlock[i], &colorBlock[j] );
+      if ( distance > maxDistance ) {
+	maxDistance = distance;
+	memcpy( minColor, colorBlock+i, 3 );
+	memcpy( maxColor, colorBlock+j, 3 );
+      }
+    }
+  }
+  if ( ColorTo565( maxColor ) < ColorTo565( minColor ) ) {
+    SwapColors( minColor, maxColor );
+  }
+}
+
+
+int ColorLuminance( const byte *color )
+{
+  return ( color[0] + color[1] * 2 + color[2] );
+}
+
+
+void GetMinMaxColorsByLuminance( const byte *colorBlock, byte *minColor, byte *maxColor )
+{
+  int maxLuminance = -1, minLuminance = MAX_INT;
+  for (int i = 0; i < 16; i++ ) {
+    int luminance = ColorLuminance( colorBlock+i*4 );
+    if ( luminance > maxLuminance ) {
+      maxLuminance = luminance;
+      memcpy( maxColor, colorBlock+i*4, 3 );
+    }
+    if ( luminance < minLuminance ) {
+      minLuminance = luminance;
+      memcpy( minColor, colorBlock+i*4, 3 );
+    }
+  }
+  if ( ColorTo565( maxColor ) < ColorTo565( minColor ) ) {
+    SwapColors( minColor, maxColor );
+  }
+}
+
+void GetMinMaxColorsByBBox( const byte *colorBlock, byte *minColor, byte *maxColor )
+{
+  int i;
+  byte inset[3];
+  minColor[0] = minColor[1] = minColor[2] = 255;
+  maxColor[0] = maxColor[1] = maxColor[2] = 0;
+  for ( i = 0; i < 16; i++ ) {
+    if ( colorBlock[i*4+0] < minColor[0] ) { minColor[0] = colorBlock[i*4+0]; }
+    if ( colorBlock[i*4+1] < minColor[1] ) { minColor[1] = colorBlock[i*4+1]; }
+    if ( colorBlock[i*4+2] < minColor[2] ) { minColor[2] = colorBlock[i*4+2]; }
+    if ( colorBlock[i*4+0] > maxColor[0] ) { maxColor[0] = colorBlock[i*4+0]; }
+    if ( colorBlock[i*4+1] > maxColor[1] ) { maxColor[1] = colorBlock[i*4+1]; }
+    if ( colorBlock[i*4+2] > maxColor[2] ) { maxColor[2] = colorBlock[i*4+2]; }
+  }
+  inset[0] = ( maxColor[0] - minColor[0] ) >> INSET_SHIFT;
+  inset[1] = ( maxColor[1] - minColor[1] ) >> INSET_SHIFT;
+  inset[2] = ( maxColor[2] - minColor[2] ) >> INSET_SHIFT;
+  minColor[0] = ( minColor[0] + inset[0] <= 255 ) ? minColor[0] + inset[0] : 255;
+  minColor[1] = ( minColor[1] + inset[1] <= 255 ) ? minColor[1] + inset[1] : 255;
+  minColor[2] = ( minColor[2] + inset[2] <= 255 ) ? minColor[2] + inset[2] : 255;
+  maxColor[0] = ( maxColor[0] >= inset[0] ) ? maxColor[0] - inset[0] : 0;
+  maxColor[1] = ( maxColor[1] >= inset[1] ) ? maxColor[1] - inset[1] : 0;
+  maxColor[2] = ( maxColor[2] >= inset[2] ) ? maxColor[2] - inset[2] : 0;
+}
+
+
+//
+// GetMinMaxColorsAlpha for DXT5
+//
+void GetMinMaxColorsAlpha(  byte *colorBlock, byte *minColor, byte *maxColor )
+{
+  int i;
+  byte inset[4];
+  byte y,cg, co, r, g, b;
+
+  minColor[0] = minColor[1] = minColor[2] = minColor[3] = 255;
+  maxColor[0] = maxColor[1] = maxColor[2] = maxColor[3] = 0;
+
+  for ( i = 0; i < 16; i++ ) {
+    r = colorBlock[i*4+0];
+    g = colorBlock[i*4+1];
+    b = colorBlock[i*4+2];
+    y  = (g>>1) + ((r+b)>>2);
+    cg = g - ((r+b)>>1);
+    co = r - b;
+
+    colorBlock[i*4+0] = co;
+    colorBlock[i*4+1] = cg;
+    colorBlock[i*4+2] = 0;
+    colorBlock[i*4+3] = y;
+
+    if ( colorBlock[i*4+0] < minColor[0] ) { minColor[0] = colorBlock[i*4+0]; }
+    if ( colorBlock[i*4+1] < minColor[1] ) { minColor[1] = colorBlock[i*4+1]; }
+    if ( colorBlock[i*4+2] < minColor[2] ) { minColor[2] = colorBlock[i*4+2]; }
+    if ( colorBlock[i*4+3] < minColor[3] ) { minColor[3] = colorBlock[i*4+3]; }
+    if ( colorBlock[i*4+0] > maxColor[0] ) { maxColor[0] = colorBlock[i*4+0]; }
+    if ( colorBlock[i*4+1] > maxColor[1] ) { maxColor[1] = colorBlock[i*4+1]; }
+    if ( colorBlock[i*4+2] > maxColor[2] ) { maxColor[2] = colorBlock[i*4+2]; }
+    if ( colorBlock[i*4+3] > maxColor[3] ) { maxColor[3] = colorBlock[i*4+3]; }
+  }
+
+  inset[0] = ( maxColor[0] - minColor[0] ) >> INSET_SHIFT;
+  inset[1] = ( maxColor[1] - minColor[1] ) >> INSET_SHIFT;
+  inset[2] = ( maxColor[2] - minColor[2] ) >> INSET_SHIFT;
+  inset[3] = ( maxColor[3] - minColor[3] ) >> INSET_SHIFT;
+
+  minColor[0] = ( minColor[0] + inset[0] <= 255 ) ? minColor[0] + inset[0] : 255;
+  minColor[1] = ( minColor[1] + inset[1] <= 255 ) ? minColor[1] + inset[1] : 255;
+  minColor[2] = ( minColor[2] + inset[2] <= 255 ) ? minColor[2] + inset[2] : 255;
+  minColor[3] = ( minColor[3] + inset[3] <= 255 ) ? minColor[3] + inset[3] : 255;
+
+  maxColor[0] = ( maxColor[0] >= inset[0] ) ? maxColor[0] - inset[0] : 0;
+  maxColor[1] = ( maxColor[1] >= inset[1] ) ? maxColor[1] - inset[1] : 0;
+  maxColor[2] = ( maxColor[2] >= inset[2] ) ? maxColor[2] - inset[2] : 0;
+  maxColor[3] = ( maxColor[3] >= inset[3] ) ? maxColor[3] - inset[3] : 0;
+}
+
+
+void EmitColorIndices( const byte *colorBlock, const byte *minColor, const byte *maxColor, byte *&outData )
+{
+  byte colors[4][4];
+  unsigned int indices[16];
+  
+  colors[0][0] = ( maxColor[0] & C565_5_MASK ) | ( maxColor[0] >> 5 );
+  colors[0][1] = ( maxColor[1] & C565_6_MASK ) | ( maxColor[1] >> 6 );
+  colors[0][2] = ( maxColor[2] & C565_5_MASK ) | ( maxColor[2] >> 5 );
+
+  colors[1][0] = ( minColor[0] & C565_5_MASK ) | ( minColor[0] >> 5 );
+  colors[1][1] = ( minColor[1] & C565_6_MASK ) | ( minColor[1] >> 6 );
+  colors[1][2] = ( minColor[2] & C565_5_MASK ) | ( minColor[2] >> 5 );
+
+  colors[2][0] = ( 2 * colors[0][0] + 1 * colors[1][0] ) / 3;
+  colors[2][1] = ( 2 * colors[0][1] + 1 * colors[1][1] ) / 3;
+  colors[2][2] = ( 2 * colors[0][2] + 1 * colors[1][2] ) / 3;
+
+  colors[3][0] = ( 1 * colors[0][0] + 2 * colors[1][0] ) / 3;
+  colors[3][1] = ( 1 * colors[0][1] + 2 * colors[1][1] ) / 3;
+  colors[3][2] = ( 1 * colors[0][2] + 2 * colors[1][2] ) / 3;
+
+  for ( int i = 0; i < 16; i++ ) {
+    unsigned int minDistance = MAX_INT;
+    for ( int j = 0; j < 4; j++ ) {
+      unsigned int dist = ColorDistance( &colorBlock[i*4], &colors[j][0] );
+      if ( dist < minDistance ) {
+	minDistance = dist;
+	indices[i] = j;
+      }
+    }
+  }
+  dword result = 0;
+  for ( int i = 0; i < 16; i++ ) {
+    result |= ( indices[i] << (unsigned int)( i << 1 ) );
+  }
+  EmitDoubleWord( result, outData );
+}
+
+
+void EmitColorIndicesFast( const byte *colorBlock, const byte *minColor, const byte *maxColor, byte *&outData )
+{
+  word colors[4][4];
+  dword result = 0;
+
+  colors[0][0] = ( maxColor[0] & C565_5_MASK ) | ( maxColor[0] >> 5 );
+  colors[0][1] = ( maxColor[1] & C565_6_MASK ) | ( maxColor[1] >> 6 );
+  colors[0][2] = ( maxColor[2] & C565_5_MASK ) | ( maxColor[2] >> 5 );
+  colors[1][0] = ( minColor[0] & C565_5_MASK ) | ( minColor[0] >> 5 );
+  colors[1][1] = ( minColor[1] & C565_6_MASK ) | ( minColor[1] >> 6 );
+  colors[1][2] = ( minColor[2] & C565_5_MASK ) | ( minColor[2] >> 5 );
+  colors[2][0] = ( 2 * colors[0][0] + 1 * colors[1][0] ) / 3;
+  colors[2][1] = ( 2 * colors[0][1] + 1 * colors[1][1] ) / 3;
+  colors[2][2] = ( 2 * colors[0][2] + 1 * colors[1][2] ) / 3;
+  colors[3][0] = ( 1 * colors[0][0] + 2 * colors[1][0] ) / 3;
+  colors[3][1] = ( 1 * colors[0][1] + 2 * colors[1][1] ) / 3;
+  colors[3][2] = ( 1 * colors[0][2] + 2 * colors[1][2] ) / 3;
+
+  for ( int i = 15; i >= 0; i-- ) {
+    int c0 = colorBlock[i*4+0];
+    int c1 = colorBlock[i*4+1];
+    int c2 = colorBlock[i*4+2];
+    int d0 = abs( colors[0][0] - c0 ) + abs( colors[0][1] - c1 ) + abs( colors[0][2] - c2 );
+    int d1 = abs( colors[1][0] - c0 ) + abs( colors[1][1] - c1 ) + abs( colors[1][2] - c2 );
+    int d2 = abs( colors[2][0] - c0 ) + abs( colors[2][1] - c1 ) + abs( colors[2][2] - c2 );
+    int d3 = abs( colors[3][0] - c0 ) + abs( colors[3][1] - c1 ) + abs( colors[3][2] - c2 );
+
+    int b0 = d0 > d3;
+    int b1 = d1 > d2;
+    int b2 = d0 > d2;
+    int b3 = d1 > d3;
+    int b4 = d2 > d3;
+
+    int x0 = b1 & b2;
+    int x1 = b0 & b3;
+    int x2 = b0 & b4;
+    result |= ( x2 | ( ( x0 | x1 ) << 1 ) ) << ( i << 1 );
+  }
+  EmitDoubleWord( result, outData );
+}
+
+
+//
+// Emit indices for DXT5
+//
+void EmitAlphaIndices( const byte *colorBlock, const byte minAlpha, const byte maxAlpha, byte *&outData )
+{
+  byte indices[16];
+  byte alphas[8];
+
+  alphas[0] = maxAlpha;
+  alphas[1] = minAlpha;
+  alphas[2] = ( 6 * maxAlpha + 1 * minAlpha ) / 7;
+  alphas[3] = ( 5 * maxAlpha + 2 * minAlpha ) / 7;
+  alphas[4] = ( 4 * maxAlpha + 3 * minAlpha ) / 7;
+  alphas[5] = ( 3 * maxAlpha + 4 * minAlpha ) / 7;
+  alphas[6] = ( 2 * maxAlpha + 5 * minAlpha ) / 7;
+  alphas[7] = ( 1 * maxAlpha + 6 * minAlpha ) / 7;
+
+  colorBlock += 3;
+
+  for ( int i = 0; i < 16; i++ ) {
+    int minDistance = MAX_INT;
+    byte a = colorBlock[i*4];
+    for ( int j = 0; j < 8; j++ ) {
+      int dist = abs( a - alphas[j] );
+      if ( dist < minDistance ) {
+	minDistance = dist; indices[i] = j;
+      }
+    }
+  }
+
+  EmitByte( (indices[ 0] >> 0) | (indices[ 1] << 3) | (indices[ 2] << 6) , outData);
+  EmitByte( (indices[ 2] >> 2) | (indices[ 3] << 1) | (indices[ 4] << 4) | (indices[ 5] << 7) , outData);
+  EmitByte( (indices[ 5] >> 1) | (indices[ 6] << 2) | (indices[ 7] << 5) , outData);
+  EmitByte( (indices[ 8] >> 0) | (indices[ 9] << 3) | (indices[10] << 6) , outData);
+  EmitByte( (indices[10] >> 2) | (indices[11] << 1) | (indices[12] << 4) | (indices[13] << 7) , outData);
+  EmitByte( (indices[13] >> 1) | (indices[14] << 2) | (indices[15] << 5) , outData);
+}
+
+
+void EmitAlphaIndicesFast( const byte *colorBlock, const byte minAlpha, const byte maxAlpha, byte *&outData )
+{
+  //assert( maxAlpha > minAlpha );
+
+  byte indices[16];
+  byte mid = ( maxAlpha - minAlpha ) / ( 2 * 7 );
+  byte ab1 = minAlpha + mid;
+  byte ab2 = ( 6 * maxAlpha + 1 * minAlpha ) / 7 + mid;
+  byte ab3 = ( 5 * maxAlpha + 2 * minAlpha ) / 7 + mid;
+  byte ab4 = ( 4 * maxAlpha + 3 * minAlpha ) / 7 + mid;
+  byte ab5 = ( 3 * maxAlpha + 4 * minAlpha ) / 7 + mid;
+  byte ab6 = ( 2 * maxAlpha + 5 * minAlpha ) / 7 + mid;
+  byte ab7 = ( 1 * maxAlpha + 6 * minAlpha ) / 7 + mid;
+
+  colorBlock += 3;
+
+  for ( int i = 0; i < 16; i++ ) {
+
+    byte a = colorBlock[i*4];
+
+    int b1 = ( a <= ab1 );
+    int b2 = ( a <= ab2 );
+    int b3 = ( a <= ab3 );
+    int b4 = ( a <= ab4 );
+    int b5 = ( a <= ab5 );
+    int b6 = ( a <= ab6 );
+    int b7 = ( a <= ab7 );
+
+    int index = ( b1 + b2 + b3 + b4 + b5 + b6 + b7 + 1 ) & 7;
+
+    indices[i] = index ^ ( 2 > index );
+  }
+
+  EmitByte( (indices[ 0] >> 0) | (indices[ 1] << 3) | (indices[ 2] << 6) , outData);
+  EmitByte( (indices[ 2] >> 2) | (indices[ 3] << 1) | (indices[ 4] << 4) | (indices[ 5] << 7) , outData);
+  EmitByte( (indices[ 5] >> 1) | (indices[ 6] << 2) | (indices[ 7] << 5) , outData);
+  EmitByte( (indices[ 8] >> 0) | (indices[ 9] << 3) | (indices[10] << 6) , outData);
+  EmitByte( (indices[10] >> 2) | (indices[11] << 1) | (indices[12] << 4) | (indices[13] << 7) , outData);
+  EmitByte( (indices[13] >> 1) | (indices[14] << 2) | (indices[15] << 5) , outData);
+}
+
+
+double ComputeError( const byte *original, const byte *dxt, int width, int height)
+{
+  // Compute RMS error
+  double error;
+  int s, d;
+
+  error = 0.0;
+
+  // dxt: pointer to data read back from the framebuffer. RGB data upside down.
+  for (int i=0; i<height; i++)
+    {
+      for (int j=0; j<width; j++)
+	{
+	  s = original[4*(width*i+j)+0];
+	  d = dxt[3*(width*(height-i-1)+j)+0];
+	  error += (s-d) * (s-d);
+	  
+	  s = original[4*(width*i+j)+1];
+	  d = dxt[3*(width*(height-i-1)+j)+1];
+	  error += (s-d) * (s-d);
+	  
+	  s = original[4*(width*i+j)+2];
+	  d = dxt[3*(width*(height-i-1)+j)+2];
+	  error += (s-d) * (s-d);
+	}
+    }
+  error = sqrt( error / (double)( width*height ) );
+
+  return error;
+}

--- a/qt/tileedit/extern/fastdxt/dxt.cpp
+++ b/qt/tileedit/extern/fastdxt/dxt.cpp
@@ -7,7 +7,7 @@
 #include "util.h"
 
 
-#define DXT_INTR 1
+//#define DXT_INTR 1
 
 void ExtractBlock( const byte *inPtr, int width, byte *colorBlock );
 void ExtractBlock_Intrinsics( const byte *inPtr, int width, byte *colorBlock );

--- a/qt/tileedit/extern/fastdxt/dxt.h
+++ b/qt/tileedit/extern/fastdxt/dxt.h
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Fast DXT - a realtime DXT compression tool
+ *
+ * Author : Luc Renambot
+ *
+ * Copyright (C) 2007 Electronic Visualization Laboratory,
+ * University of Illinois at Chicago
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either Version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ *****************************************************************************/
+
+// From:
+//    Real-Time DXT Compression
+//    May 20th 2006 J.M.P. van Waveren
+//    (c) 2006, Id Software, Inc.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string.h>
+#include <math.h>
+
+typedef unsigned char byte;
+typedef unsigned short word;
+typedef unsigned int dword;
+
+#define C565_5_MASK 0xF8 // 0xFF minus last three bits
+#define C565_6_MASK 0xFC // 0xFF minus last two bits
+
+#define INSET_SHIFT 4 // inset the bounding box with ( range >> shift )
+
+#if !defined(MAX_INT)
+#define       MAX_INT         2147483647      /* max value for an int 32 */
+#define       MIN_INT         (-2147483647-1) /* min value for an int 32 */
+#endif
+
+
+#if defined(__GNUC__)
+#define   ALIGN16(_x)   _x __attribute((aligned(16)))
+#else
+#define   ALIGN16( x ) __declspec(align(16)) x
+#endif
+
+
+// Compress to DXT1 format
+void CompressImageDXT1( const byte *inBuf, byte *outBuf, int width, int height, int &outputBytes );
+
+// Compress to DXT5 format
+void CompressImageDXT5( const byte *inBuf, byte *outBuf, int width, int height, int &outputBytes );
+
+// Compress to DXT5 format, first convert to YCoCg color space
+void CompressImageDXT5YCoCg( const byte *inBuf, byte *outBuf, int width, int height, int &outputBytes );
+
+// Compute error between two images
+double ComputeError( const byte *original, const byte *dxt, int width, int height);

--- a/qt/tileedit/extern/fastdxt/fastdxt.vcxproj
+++ b/qt/tileedit/extern/fastdxt/fastdxt.vcxproj
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9D0058F5-B01B-44EE-9B3F-5852E37C7047}</ProjectGuid>
+    <RootNamespace>fastdxt</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="dxt.h" />
+    <ClInclude Include="libdxt.h" />
+    <ClInclude Include="util.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dxt.cpp" />
+    <ClCompile Include="intrinsic.cpp" />
+    <ClCompile Include="libdxt.cpp" />
+    <ClCompile Include="util.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/qt/tileedit/extern/fastdxt/fastdxt.vcxproj
+++ b/qt/tileedit/extern/fastdxt/fastdxt.vcxproj
@@ -41,7 +41,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>

--- a/qt/tileedit/extern/fastdxt/fastdxt.vcxproj.filters
+++ b/qt/tileedit/extern/fastdxt/fastdxt.vcxproj.filters
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="dxt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libdxt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dxt.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="intrinsic.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libdxt.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/qt/tileedit/extern/fastdxt/intrinsic.cpp
+++ b/qt/tileedit/extern/fastdxt/intrinsic.cpp
@@ -1,0 +1,521 @@
+/******************************************************************************
+ * Fast DXT - a realtime DXT compression tool
+ *
+ * Author : Luc Renambot
+ *
+ * Copyright (C) 2007 Electronic Visualization Laboratory,
+ * University of Illinois at Chicago
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either Version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ *****************************************************************************/
+
+/*
+	Code convert from asm to intrinsics from:
+		Copyright (C) 2006 Id Software, Inc.
+		Written by J.M.P. van Waveren
+		This code is free software; you can redistribute it and/or
+		modify it under the terms of the GNU Lesser General Public
+		License as published by the Free Software Foundation; either
+		version 2.1 of the License, or (at your option) any later version.
+		This code is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+		Lesser General Public License for more details.
+*/
+
+#include "dxt.h"
+
+#include <emmintrin.h>  // sse2
+
+
+void ExtractBlock_Intrinsics( const byte *inPtr, int width, byte *colorBlock ) 
+{
+        __m128i t0, t1, t2, t3;
+	register int w = width << 2;  // width*4
+
+        t0 = _mm_load_si128 ( (__m128i*) inPtr );
+        _mm_store_si128 ( (__m128i*) &colorBlock[0], t0 );   // copy first row, 16bytes
+
+        t1 = _mm_load_si128 ( (__m128i*) (inPtr + w) );
+        _mm_store_si128 ( (__m128i*) &colorBlock[16], t1 );   // copy second row
+
+        t2 = _mm_load_si128 ( (__m128i*) (inPtr + 2*w) );
+        _mm_store_si128 ( (__m128i*) &colorBlock[32], t2 );   // copy third row
+
+	inPtr = inPtr + w;     // add width, intead of *3
+
+        t3 = _mm_load_si128 ( (__m128i*) (inPtr + 2*w) );
+        _mm_store_si128 ( (__m128i*) &colorBlock[48], t3 );   // copy last row
+}
+
+#define R_SHUFFLE_D( x, y, z, w ) (( (w) & 3 ) << 6 | ( (z) & 3 ) << 4 | ( (y) & 3 ) << 2 | ( (x) & 3 ))
+
+ALIGN16( static byte SIMD_SSE2_byte_0[16] ) = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+void GetMinMaxColors_Intrinsics( const byte *colorBlock, byte *minColor, byte *maxColor )
+{
+    __m128i t0, t1, t3, t4, t6, t7;
+
+    // get bounding box
+    // ----------------
+    
+    // load the first row
+    t0 = _mm_load_si128 ( (__m128i*) colorBlock );
+    t1 = _mm_load_si128 ( (__m128i*) colorBlock );
+
+    __m128i t16 = _mm_load_si128 ( (__m128i*) (colorBlock+16) );
+    // Minimum of Packed Unsigned Byte Integers
+    t0 = _mm_min_epu8 ( t0, t16);
+    // Maximum of Packed Unsigned Byte Integers
+    t1 = _mm_max_epu8 ( t1, t16);
+    
+    __m128i t32 = _mm_load_si128 ( (__m128i*) (colorBlock+32) );
+    t0 = _mm_min_epu8 ( t0, t32);
+    t1 = _mm_max_epu8 ( t1, t32);
+    
+    __m128i t48 = _mm_load_si128 ( (__m128i*) (colorBlock+48) );
+    t0 = _mm_min_epu8 ( t0, t48);
+    t1 = _mm_max_epu8 ( t1, t48);
+    
+    // Shuffle Packed Doublewords
+    t3 = _mm_shuffle_epi32( t0, R_SHUFFLE_D( 2, 3, 2, 3 ) );
+    t4 = _mm_shuffle_epi32( t1, R_SHUFFLE_D( 2, 3, 2, 3 ) );
+    
+    t0 = _mm_min_epu8 ( t0, t3);
+    t1 = _mm_max_epu8 ( t1, t4);
+    
+    // Shuffle Packed Low Words
+    t6 = _mm_shufflelo_epi16( t0, R_SHUFFLE_D( 2, 3, 2, 3 ) );
+    t7 = _mm_shufflelo_epi16( t1, R_SHUFFLE_D( 2, 3, 2, 3 ) );
+    
+    t0 = _mm_min_epu8 ( t0, t6);
+    t1 = _mm_max_epu8 ( t1, t7);
+    
+    // inset the bounding box
+    // ----------------------
+    
+    // Unpack Low Data
+    //__m128i t66 = _mm_set1_epi8( 0 );
+    __m128i t66 = _mm_load_si128 ( (__m128i*) SIMD_SSE2_byte_0 );
+    t0 = _mm_unpacklo_epi8(t0, t66);
+    t1 = _mm_unpacklo_epi8(t1, t66);
+    
+    // copy (movdqa)
+    //__m128i t2 = _mm_load_si128 ( &t1 );
+    __m128i t2 = t1;
+    
+    // Subtract Packed Integers
+    t2 = _mm_sub_epi16(t2, t0);
+    
+    // Shift Packed Data Right Logical 
+    t2 = _mm_srli_epi16(t2, INSET_SHIFT);
+    
+    // Add Packed Integers
+    t0 = _mm_add_epi16(t0, t2);
+    
+    t1 = _mm_sub_epi16(t1, t2);
+    
+    // Pack with Unsigned Saturation
+    t0 = _mm_packus_epi16(t0, t0);
+    t1 = _mm_packus_epi16(t1, t1);
+    
+    // store bounding box extents
+    // --------------------------
+    _mm_store_si128 ( (__m128i*) minColor, t0 );
+    _mm_store_si128 ( (__m128i*) maxColor, t1 );
+}
+
+
+ALIGN16( static word SIMD_SSE2_word_0[8] ) = { 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000 };
+ALIGN16( static word SIMD_SSE2_word_1[8] ) = { 0x0001, 0x0001, 0x0001, 0x0001, 0x0001, 0x0001, 0x0001, 0x0001 };
+ALIGN16( static word SIMD_SSE2_word_2[8] ) = { 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002 };
+ALIGN16( static word SIMD_SSE2_word_div_by_3[8] ) = { (1<<16)/3+1, (1<<16)/3+1, (1<<16)/3+1, (1<<16)/3+1, (1<<16)/3+1, (1<<16)/3+1, (1<<16)/3+1, (1<<16)/3+1 };
+ALIGN16( static byte SIMD_SSE2_byte_colorMask[16] ) = { C565_5_MASK, C565_6_MASK, C565_5_MASK, 0x00, 0x00, 0x00, 0x00, 0x00, C565_5_MASK, C565_6_MASK, C565_5_MASK, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+void EmitColorIndices_Intrinsics( const byte *colorBlock, const byte *minColor, const byte *maxColor, byte *&outData )
+{
+	ALIGN16( byte color0[16] );
+	ALIGN16( byte color1[16] );
+	ALIGN16( byte color2[16] );
+	ALIGN16( byte color3[16] );
+	ALIGN16( byte result[16] );
+	
+	// mov esi, maxColor
+	// mov edi, minColor
+
+	__m128i t0, t1, t2, t3, t4, t5, t6, t7;
+
+	t7 = _mm_setzero_si128();
+	//t7 = _mm_xor_si128(t7, t7);
+	_mm_store_si128 ( (__m128i*) &result, t7 );
+
+
+	//t0 = _mm_load_si128 ( (__m128i*)  maxColor );
+	t0 = _mm_cvtsi32_si128( *(int*)maxColor);
+
+	// Bitwise AND
+	__m128i tt = _mm_load_si128 ( (__m128i*) SIMD_SSE2_byte_colorMask );
+	t0 = _mm_and_si128(t0, tt);
+
+	t0 = _mm_unpacklo_epi8(t0, t7);
+
+	t4 = _mm_shufflelo_epi16( t0, R_SHUFFLE_D( 0, 3, 2, 3 ));
+	t5 = _mm_shufflelo_epi16( t0, R_SHUFFLE_D( 3, 1, 3, 3 ));
+
+	t4 = _mm_srli_epi16(t4, 5);
+	t5 = _mm_srli_epi16(t5, 6);
+
+	// Bitwise Logical OR
+	t0 = _mm_or_si128(t0, t4);
+	t0 = _mm_or_si128(t0, t5);   // t0 contains color0 in 565
+
+
+
+
+	//t1 = _mm_load_si128 ( (__m128i*)  minColor );
+	t1 = _mm_cvtsi32_si128( *(int*)minColor);
+
+	t1 = _mm_and_si128(t1, tt);
+
+	t1 = _mm_unpacklo_epi8(t1, t7);
+
+	t4 = _mm_shufflelo_epi16( t1, R_SHUFFLE_D( 0, 3, 2, 3 ));
+	t5 = _mm_shufflelo_epi16( t1, R_SHUFFLE_D( 3, 1, 3, 3 ));
+
+	t4 = _mm_srli_epi16(t4, 5);
+	t5 = _mm_srli_epi16(t5, 6);
+
+	t1 = _mm_or_si128(t1, t4);
+	t1 = _mm_or_si128(t1, t5);  // t1 contains color1 in 565
+
+
+
+	t2 = t0;
+
+	t2 = _mm_packus_epi16(t2, t7);
+
+	t2 = _mm_shuffle_epi32( t2, R_SHUFFLE_D( 0, 1, 0, 1 ));
+
+	_mm_store_si128 ( (__m128i*) &color0, t2 );
+
+	t6 = t0;
+	t6 = _mm_add_epi16(t6, t0);
+	t6 = _mm_add_epi16(t6, t1);
+
+	// Multiply Packed Signed Integers and Store High Result
+	__m128i tw3 = _mm_load_si128 ( (__m128i*) SIMD_SSE2_word_div_by_3 );
+	t6 = _mm_mulhi_epi16(t6, tw3);
+	t6 = _mm_packus_epi16(t6, t7);
+
+	t6 = _mm_shuffle_epi32( t6, R_SHUFFLE_D( 0, 1, 0, 1 ));
+
+	_mm_store_si128 ( (__m128i*) &color2, t6 );
+
+	t3 = t1;
+	t3 = _mm_packus_epi16(t3, t7);
+	t3 = _mm_shuffle_epi32( t3, R_SHUFFLE_D( 0, 1, 0, 1 ));
+
+	_mm_store_si128 ( (__m128i*) &color1, t3 );
+
+	t1 = _mm_add_epi16(t1, t1);
+	t0 = _mm_add_epi16(t0, t1);
+
+	t0 = _mm_mulhi_epi16(t0, tw3);
+	t0 = _mm_packus_epi16(t0, t7);
+
+	t0 = _mm_shuffle_epi32( t0, R_SHUFFLE_D( 0, 1, 0, 1 ));
+	_mm_store_si128 ( (__m128i*) &color3, t0 );
+
+	__m128i w0 = _mm_load_si128 ( (__m128i*) SIMD_SSE2_word_0);
+	__m128i w1 = _mm_load_si128 ( (__m128i*) SIMD_SSE2_word_1);
+	__m128i w2 = _mm_load_si128 ( (__m128i*) SIMD_SSE2_word_2);
+
+	    // mov eax, 32
+	    // mov esi, colorBlock
+	int x = 32;
+	//const byte *c = colorBlock;
+	while (x >= 0)
+	  {
+	    t3 = _mm_loadl_epi64( (__m128i*) (colorBlock+x+0));
+	    t3 = _mm_shuffle_epi32( t3, R_SHUFFLE_D( 0, 2, 1, 3 ));
+	    
+	    t5 = _mm_loadl_epi64( (__m128i*) (colorBlock+x+8));
+	    t5 = _mm_shuffle_epi32( t5, R_SHUFFLE_D( 0, 2, 1, 3 ));
+
+	    t0 = t3;
+	    t6 = t5;
+	    // Compute Sum of Absolute Difference
+	    __m128i c0 = _mm_load_si128 ( (__m128i*)  color0 );
+	    t0 = _mm_sad_epu8(t0, c0);
+	    t6 = _mm_sad_epu8(t6, c0);
+	    // Pack with Signed Saturation 
+	    t0 = _mm_packs_epi32 (t0, t6);
+
+	    t1 = t3;
+	    t6 = t5;
+	    __m128i c1 = _mm_load_si128 ( (__m128i*)  color1 );
+	    t1 = _mm_sad_epu8(t1, c1);
+	    t6 = _mm_sad_epu8(t6, c1);
+	    t1 = _mm_packs_epi32 (t1, t6);
+
+	    t2 = t3;
+	    t6 = t5;
+	    __m128i c2 = _mm_load_si128 ( (__m128i*)  color2 );
+	    t2 = _mm_sad_epu8(t2, c2);
+	    t6 = _mm_sad_epu8(t6, c2);
+	    t2 = _mm_packs_epi32 (t2, t6);
+
+	    __m128i c3 = _mm_load_si128 ( (__m128i*)  color3 );
+	    t3 = _mm_sad_epu8(t3, c3);
+	    t5 = _mm_sad_epu8(t5, c3);
+	    t3 = _mm_packs_epi32 (t3, t5);
+
+
+	    t4 = _mm_loadl_epi64( (__m128i*) (colorBlock+x+16));
+	    t4 = _mm_shuffle_epi32( t4, R_SHUFFLE_D( 0, 2, 1, 3 ));
+	    
+	    t5 = _mm_loadl_epi64( (__m128i*) (colorBlock+x+24));
+	    t5 = _mm_shuffle_epi32( t5, R_SHUFFLE_D( 0, 2, 1, 3 ));
+
+	    t6 = t4;
+	    t7 = t5;
+	    t6 = _mm_sad_epu8(t6, c0);
+	    t7 = _mm_sad_epu8(t7, c0);
+	    t6 = _mm_packs_epi32 (t6, t7);
+	    t0 = _mm_packs_epi32 (t0, t6);  // d0
+
+	    t6 = t4;
+	    t7 = t5;
+	    t6 = _mm_sad_epu8(t6, c1);
+	    t7 = _mm_sad_epu8(t7, c1);
+	    t6 = _mm_packs_epi32 (t6, t7);
+	    t1 = _mm_packs_epi32 (t1, t6);  // d1
+
+	    t6 = t4;
+	    t7 = t5;
+	    t6 = _mm_sad_epu8(t6, c2);
+	    t7 = _mm_sad_epu8(t7, c2);
+	    t6 = _mm_packs_epi32 (t6, t7);
+	    t2 = _mm_packs_epi32 (t2, t6);  // d2
+
+	    t4 = _mm_sad_epu8(t4, c3);
+	    t5 = _mm_sad_epu8(t5, c3);
+	    t4 = _mm_packs_epi32 (t4, t5);
+	    t3 = _mm_packs_epi32 (t3, t4);  // d3
+
+	    t7 = _mm_load_si128 ( (__m128i*) result );
+
+	    t7 = _mm_slli_epi32( t7, 16);
+
+	    t4 = t0;
+	    t5 = t1;
+	    // Compare Packed Signed Integers for Greater Than
+	    t0 = _mm_cmpgt_epi16(t0, t3); // b0
+	    t1 = _mm_cmpgt_epi16(t1, t2); // b1
+	    t4 = _mm_cmpgt_epi16(t4, t2); // b2
+	    t5 = _mm_cmpgt_epi16(t5, t3); // b3
+	    t2 = _mm_cmpgt_epi16(t2, t3); // b4
+	      
+	    t4 = _mm_and_si128(t4, t1); // x0
+	    t5 = _mm_and_si128(t5, t0); // x1
+	    t2 = _mm_and_si128(t2, t0); // x2
+
+	    t4 = _mm_or_si128(t4, t5);
+	    t2 = _mm_and_si128(t2, w1);
+	    t4 = _mm_and_si128(t4, w2);
+	    t2 = _mm_or_si128(t2, t4);
+
+	    t5 = _mm_shuffle_epi32( t2, R_SHUFFLE_D( 2, 3, 0, 1 ));
+
+	    // Unpack Low Data
+	    t2 = _mm_unpacklo_epi16 ( t2, w0);
+	    t5 = _mm_unpacklo_epi16 ( t5, w0);
+
+	    //t5 = _mm_slli_si128 ( t5, 8);
+	    t5 = _mm_slli_epi32( t5, 8);
+
+	    t7 = _mm_or_si128(t7, t5);
+	    t7 = _mm_or_si128(t7, t2);
+
+	    _mm_store_si128 ( (__m128i*) &result, t7 );
+
+	    x -=32;
+	  }
+
+	t4 = _mm_shuffle_epi32( t7, R_SHUFFLE_D( 1, 2, 3, 0 ));
+	t5 = _mm_shuffle_epi32( t7, R_SHUFFLE_D( 2, 3, 0, 1 ));
+	t6 = _mm_shuffle_epi32( t7, R_SHUFFLE_D( 3, 0, 1, 2 ));
+
+	t4 = _mm_slli_epi32 ( t4, 2);
+	t5 = _mm_slli_epi32 ( t5, 4);
+	t6 = _mm_slli_epi32 ( t6, 6);
+
+	t7 = _mm_or_si128(t7, t4);
+	t7 = _mm_or_si128(t7, t5);
+	t7 = _mm_or_si128(t7, t6);
+
+	//_mm_store_si128 ( (__m128i*) outData, t7 );
+
+	int r = _mm_cvtsi128_si32 (t7);
+	memcpy(outData, &r, 4);   // Anything better ?
+
+	outData += 4;
+}
+
+
+
+ALIGN16( static byte SIMD_SSE2_byte_1[16] ) = { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 };
+ALIGN16( static byte SIMD_SSE2_byte_2[16] ) = { 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02 };
+ALIGN16( static byte SIMD_SSE2_byte_7[16] ) = { 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07 };
+ALIGN16( static word SIMD_SSE2_word_div_by_7[8] ) = { (1<<16)/7+1, (1<<16)/7+1, (1<<16)/7+1, (1<<16)/7+1, (1<<16)/7+1, (1<<16)/7+1, (1<<16)/7+1, (1<<16)/7+1 };
+ALIGN16( static word SIMD_SSE2_word_div_by_14[8] ) = { (1<<16)/14+1, (1<<16)/14+1, (1<<16)/14+1, (1<<16)/14+1, (1<<16)/14+1, (1<<16)/14+1, (1<<16)/14+1, (1<<16)/14+1 };
+ALIGN16( static word SIMD_SSE2_word_scale66554400[8] ) = { 6, 6, 5, 5, 4, 4, 0, 0 };
+ALIGN16( static word SIMD_SSE2_word_scale11223300[8] ) = { 1, 1, 2, 2, 3, 3, 0, 0 };
+ALIGN16( static dword SIMD_SSE2_dword_alpha_bit_mask0[4] ) = { 7<<0, 0, 7<<0, 0 };
+ALIGN16( static dword SIMD_SSE2_dword_alpha_bit_mask1[4] ) = { 7<<3, 0, 7<<3, 0 };
+ALIGN16( static dword SIMD_SSE2_dword_alpha_bit_mask2[4] ) = { 7<<6, 0, 7<<6, 0 };
+ALIGN16( static dword SIMD_SSE2_dword_alpha_bit_mask3[4] ) = { 7<<9, 0, 7<<9, 0 };
+ALIGN16( static dword SIMD_SSE2_dword_alpha_bit_mask4[4] ) = { 7<<12, 0, 7<<12, 0 };
+ALIGN16( static dword SIMD_SSE2_dword_alpha_bit_mask5[4] ) = { 7<<15, 0, 7<<15, 0 };
+ALIGN16( static dword SIMD_SSE2_dword_alpha_bit_mask6[4] ) = { 7<<18, 0, 7<<18, 0 };
+ALIGN16( static dword SIMD_SSE2_dword_alpha_bit_mask7[4] ) = { 7<<21, 0, 7<<21, 0 };
+
+
+void EmitAlphaIndices_Intrinsics( const byte *colorBlock, const byte minAlpha, const byte maxAlpha, byte *&outData)
+{
+/*
+  __asm {
+    mov esi, colorBlock
+      movdqa xmm0, [esi+ 0]
+      movdqa xmm5, [esi+16]
+      psrld xmm0, 24
+      psrld xmm5, 24
+      packuswb xmm0, xmm5
+      movdqa xmm6, [esi+32]
+      movdqa xmm4, [esi+48]
+      psrld xmm6, 24
+      psrld xmm4, 24
+      packuswb xmm6, xmm4
+      movzx ecx, maxAlpha
+      movd xmm5, ecx
+      pshuflw xmm5, xmm5, R_SHUFFLE_D( 0, 0, 0, 0 )
+      pshufd xmm5, xmm5, R_SHUFFLE_D( 0, 0, 0, 0 )
+      movdqa xmm7, xmm5
+      movzx edx, minAlpha
+      movd xmm2, edx
+      pshuflw xmm2, xmm2, R_SHUFFLE_D( 0, 0, 0, 0 )
+      pshufd xmm2, xmm2, R_SHUFFLE_D( 0, 0, 0, 0 )
+      movdqa xmm3, xmm2
+      movdqa xmm4, xmm5
+      psubw xmm4, xmm2
+      pmulhw xmm4, SIMD_SSE2_word_div_by_14    // * ( ( 1 << 16 ) / 14 + 1 ) ) >> 16
+      movdqa xmm1, xmm2
+      paddw xmm1, xmm4
+      packuswb xmm1, xmm1                      // ab1
+      pmullw xmm5, SIMD_SSE2_word_scale66554400
+      pmullw xmm7, SIMD_SSE2_word_scale11223300
+      pmullw xmm2, SIMD_SSE2_word_scale11223300
+      pmullw xmm3, SIMD_SSE2_word_scale66554400
+      paddw xmm5, xmm2
+      paddw xmm7, xmm3
+      pmulhw xmm5, SIMD_SSE2_word_div_by_7 // * ( ( 1 << 16 ) / 7 + 1 ) ) >> 16
+      pmulhw xmm7, SIMD_SSE2_word_div_by_7 // * ( ( 1 << 16 ) / 7 + 1 ) ) >> 16
+      paddw xmm5, xmm4
+      paddw xmm7, xmm4
+      pshufd xmm2, xmm5, R_SHUFFLE_D( 0, 0, 0, 0 )
+      pshufd xmm3, xmm5, R_SHUFFLE_D( 1, 1, 1, 1 )
+      pshufd xmm4, xmm5, R_SHUFFLE_D( 2, 2, 2, 2 )
+      packuswb xmm2, xmm2 // ab2
+      packuswb xmm3, xmm3 // ab3
+      packuswb xmm4, xmm4 // ab4
+      packuswb xmm0, xmm6 // alpha values
+      pshufd xmm5, xmm7, R_SHUFFLE_D( 2, 2, 2, 2 )
+      pshufd xmm6, xmm7, R_SHUFFLE_D( 1, 1, 1, 1 )
+      pshufd xmm7, xmm7, R_SHUFFLE_D( 0, 0, 0, 0 )
+      packuswb xmm5, xmm5 // ab5
+      packuswb xmm6, xmm6 // ab6
+      packuswb xmm7, xmm7 // ab7
+      pminub xmm1, xmm0
+      pminub xmm2, xmm0
+      pminub xmm3, xmm0
+      pcmpeqb xmm1, xmm0
+      pcmpeqb xmm2, xmm0
+      pcmpeqb xmm3, xmm0
+      pminub xmm4, xmm0
+      pminub xmm5, xmm0
+      pminub xmm6, xmm0
+      pminub xmm7, xmm0
+      pcmpeqb xmm4, xmm0
+      pcmpeqb xmm5, xmm0
+      pcmpeqb xmm6, xmm0
+      pcmpeqb xmm7, xmm0
+      pand xmm1, SIMD_SSE2_byte_1
+      pand xmm2, SIMD_SSE2_byte_1
+      pand xmm3, SIMD_SSE2_byte_1
+      pand xmm4, SIMD_SSE2_byte_1
+      pand xmm5, SIMD_SSE2_byte_1
+      pand xmm6, SIMD_SSE2_byte_1
+      pand xmm7, SIMD_SSE2_byte_1
+      movdqa xmm0, SIMD_SSE2_byte_1
+      paddusb xmm0, xmm1
+      paddusb xmm2, xmm3
+      paddusb xmm4, xmm5
+      paddusb xmm6, xmm7
+      paddusb xmm0, xmm2
+      paddusb xmm4, xmm6
+      paddusb xmm0, xmm4
+      pand xmm0, SIMD_SSE2_byte_7
+      movdqa xmm1, SIMD_SSE2_byte_2
+      pcmpgtb xmm1, xmm0
+      pand xmm1, SIMD_SSE2_byte_1
+      pxor xmm0, xmm1
+      movdqa xmm1, xmm0
+      movdqa xmm2, xmm0
+      movdqa xmm3, xmm0
+      movdqa xmm4, xmm0
+      movdqa xmm5, xmm0
+      movdqa xmm6, xmm0
+      movdqa xmm7, xmm0
+      psrlq xmm1, 8- 3
+      psrlq xmm2, 16- 6
+      psrlq xmm3, 24- 9
+      psrlq xmm4, 32-12
+      psrlq xmm5, 40-15
+      psrlq xmm6, 48-18
+      psrlq xmm7, 56-21
+      pand xmm0, SIMD_SSE2_dword_alpha_bit_mask0
+      pand xmm1, SIMD_SSE2_dword_alpha_bit_mask1
+      pand xmm2, SIMD_SSE2_dword_alpha_bit_mask2
+      pand xmm3, SIMD_SSE2_dword_alpha_bit_mask3
+      pand xmm4, SIMD_SSE2_dword_alpha_bit_mask4
+      pand xmm5, SIMD_SSE2_dword_alpha_bit_mask5
+      pand xmm6, SIMD_SSE2_dword_alpha_bit_mask6
+      pand xmm7, SIMD_SSE2_dword_alpha_bit_mask7
+      por xmm0, xmm1
+      por xmm2, xmm3
+      por xmm4, xmm5
+      por xmm6, xmm7
+      por xmm0, xmm2
+      por xmm4, xmm6
+      por xmm0, xmm4
+      mov esi, outData
+      movd [esi+0], xmm0
+      pshufd xmm1, xmm0, R_SHUFFLE_D( 2, 3, 0, 1 )
+      movd [esi+3], xmm1
+      }
+  outData += 6;
+*/
+}

--- a/qt/tileedit/extern/fastdxt/libdxt.cpp
+++ b/qt/tileedit/extern/fastdxt/libdxt.cpp
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * Fast DXT - a realtime DXT compression tool
+ *
+ * Author : Luc Renambot
+ *
+ * Copyright (C) 2007 Electronic Visualization Laboratory,
+ * University of Illinois at Chicago
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either Version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ *****************************************************************************/
+
+#include "libdxt.h"
+
+#if defined(__APPLE__)
+#define memalign(x,y) malloc((y))
+#else
+#include <malloc.h>
+#endif
+
+typedef struct _work_t {
+	int width, height;
+	int nbb;
+	byte *in, *out;
+} work_t;
+
+
+
+void *slave1(void *arg)
+{
+	work_t *param = (work_t*) arg;
+	int nbbytes = 0;
+	CompressImageDXT1( param->in, param->out, param->width, param->height, nbbytes);
+	param->nbb = nbbytes;
+	return NULL;
+}
+
+void *slave5(void *arg)
+{
+	work_t *param = (work_t*) arg;
+	int nbbytes = 0;
+	CompressImageDXT5( param->in, param->out, param->width, param->height, nbbytes);
+	param->nbb = nbbytes;	
+	return NULL;
+}
+
+void *slave5ycocg(void *arg)
+{
+	work_t *param = (work_t*) arg;
+	int nbbytes = 0;
+	CompressImageDXT5YCoCg( param->in, param->out, param->width, param->height, nbbytes);
+	param->nbb = nbbytes;
+	return NULL;
+}
+
+int CompressDXT(const byte *in, byte *out, int width, int height, int format)
+{ 
+  int        nbbytes;
+
+  work_t job;
+
+  job.width = width;
+  job.height = height;
+  job.nbb = 0;
+  job.in =  (byte*)in;
+  job.out = out;
+  
+  switch (format) {
+      case FORMAT_DXT1:
+          slave1(&job);
+          break;
+      case FORMAT_DXT5:
+          slave5(&job);
+          break;
+      case FORMAT_DXT5YCOCG:
+          slave5ycocg(&job);
+          break;
+  }
+
+  // Join all the threads
+  nbbytes = job.nbb;
+  return nbbytes;
+}

--- a/qt/tileedit/extern/fastdxt/libdxt.h
+++ b/qt/tileedit/extern/fastdxt/libdxt.h
@@ -1,0 +1,34 @@
+/******************************************************************************
+ * Fast DXT - a realtime DXT compression tool
+ *
+ * Author : Luc Renambot
+ *
+ * Copyright (C) 2007 Electronic Visualization Laboratory,
+ * University of Illinois at Chicago
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either Version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ *****************************************************************************/
+
+#include "dxt.h"
+#include "util.h"
+
+#define FORMAT_DXT1      1
+#define FORMAT_DXT5      2
+#define FORMAT_DXT5YCOCG 3
+
+
+int CompressDXT(const byte *in, byte *out, int width, int height, int format);
+

--- a/qt/tileedit/extern/fastdxt/readme.txt
+++ b/qt/tileedit/extern/fastdxt/readme.txt
@@ -1,0 +1,4 @@
+Copied from: https://github.com/gwaldron/osgearth/tree/master/src/osgEarthDrivers/fastdxt
+Copied on: 190705
+
+FastDXT home page: https://www.evl.uic.edu/cavern/fastdxt/

--- a/qt/tileedit/extern/fastdxt/util.cpp
+++ b/qt/tileedit/extern/fastdxt/util.cpp
@@ -1,0 +1,342 @@
+/******************************************************************************
+ * Fast DXT - a realtime DXT compression tool
+ *
+ * Author : Luc Renambot
+ *
+ * Copyright (C) 2007 Electronic Visualization Laboratory,
+ * University of Illinois at Chicago
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either Version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ *****************************************************************************/
+
+#include "util.h"
+
+
+#if defined(WIN32)
+#include <io.h>
+LARGE_INTEGER perf_freq;
+LARGE_INTEGER perf_start;
+HANDLE win_err; // stderr in a console
+#elif defined(__APPLE__)
+#include <mach/mach_time.h>
+static double perf_conversion = 0.0;
+static uint64_t perf_start;
+#else
+struct timeval tv_start;
+#endif
+
+#if !defined(WIN32)
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <fcntl.h>
+
+
+void aInitialize()
+{
+#if defined(WIN32)
+	QueryPerformanceCounter(&perf_start);
+	QueryPerformanceFrequency(&perf_freq);
+	AllocConsole();
+	win_err =  GetStdHandle(STD_ERROR_HANDLE);
+#elif defined(__APPLE__)
+	if( perf_conversion == 0.0 )
+	{
+		mach_timebase_info_data_t info;
+		kern_return_t err = mach_timebase_info( &info );
+
+		//Convert the timebase into seconds
+		if( err == 0  )
+			perf_conversion = 1e-9 * (double) info.numer / (double) info.denom;
+	}
+		// Start of time
+	perf_start = mach_absolute_time();
+
+		// Initialize the random generator
+	srand(getpid());
+#else
+		// Start of time
+	gettimeofday(&tv_start,0);
+		// Initialize the random generator
+	srand(getpid());
+#endif
+}
+
+double aTime()
+// return time since start of process in seconds
+{
+#if defined(WIN32)
+    LARGE_INTEGER perf_counter;
+#else
+    struct timeval tv;
+#endif
+
+#if defined(WIN32)
+        // Windows: get performance counter and subtract starting mark
+	QueryPerformanceCounter(&perf_counter);
+	return (double)(perf_counter.QuadPart - perf_start.QuadPart) / (double)perf_freq.QuadPart;
+#elif defined(__APPLE__)
+    uint64_t difference = mach_absolute_time() - perf_start;
+    return perf_conversion * (double) difference;
+#else
+        // UNIX: gettimeofday
+	gettimeofday(&tv,0);
+	return (double)(tv.tv_sec - tv_start.tv_sec) + (double)(tv.tv_usec - tv_start.tv_usec) / 1000000.0;
+#endif
+}
+
+
+
+void aLog(const char* format,...)
+{
+	va_list vl;
+	char line[2048];
+
+	va_start(vl,format);
+	vsprintf(line,format,vl);
+	va_end(vl);
+
+#if defined(WIN32)
+	DWORD res;
+	WriteFile(win_err, line, (DWORD)strlen(line), &res, NULL);
+#endif
+	fprintf(stderr,"%s",line);
+	fflush(stderr);
+}
+
+void aError(const char* format,...)
+{
+	va_list vl;
+	char line[2048];
+
+	va_start(vl,format);
+	vsprintf(line,format,vl);
+	va_end(vl);
+
+#if defined(WIN32)
+	DWORD res;
+	WriteFile(win_err, line, (DWORD)strlen(line), &res, NULL);
+#endif
+	fprintf(stderr,"%s",line);
+	fflush(stderr);
+
+    exit(1);
+}
+
+
+
+void* aAlloc(size_t const n)
+{
+	void* result;
+#if defined(WIN32)
+	result = LocalAlloc(0,n);
+#else
+	result = malloc(n);
+#endif
+	// Filling with zeros
+	memset(result, 0, n);
+
+	if(!result)
+		aError("Aura: not enough memory for %d bytes",n);
+	return result;
+}
+
+void aFree(void* const p)
+{
+#if defined(WIN32)
+	LocalFree(p);
+#else
+	if (p)
+        free(p);
+    else
+        aError("Alloc> Trying to free a NULL pointer\n");
+#endif
+}
+
+#if defined(WIN32)
+float
+drand48(void)
+{
+	return (((float) rand()) / RAND_MAX);
+}
+#endif
+
+
+void *aligned_malloc(size_t size, size_t align_size) {
+
+  char *ptr,*ptr2,*aligned_ptr;
+  int align_mask = (int)align_size - 1;
+
+  ptr=(char *)malloc(size + align_size + sizeof(int));
+  if(ptr==NULL) return(NULL);
+
+  ptr2 = ptr + sizeof(int);
+  aligned_ptr = ptr2 + (align_size - ((size_t)ptr2 & align_mask));
+
+
+  ptr2 = aligned_ptr - sizeof(int);
+  *((int *)ptr2)=(int)(aligned_ptr - ptr);
+
+  return(aligned_ptr);
+}
+
+void aligned_free(void *ptr)
+{
+	int *ptr2=(int *)ptr - 1;
+	ptr = (char*)ptr - *ptr2;
+	free(ptr);
+}
+
+
+/// File findind
+// From Nvidia toolkit
+
+using namespace std;
+
+string data_path::get_path(std::string filename)
+{
+  FILE* fp;
+  bool found = false;
+  for(unsigned int i=0; i < path.size(); i++)
+    {
+      path_name = path[i] + "/" + filename;
+      fp = ::fopen(path_name.c_str(), "r");
+
+      if(fp != 0)
+        {     
+	  fclose(fp);
+	  found = true;
+	  break;
+        }
+    }
+  
+  if (found == false)
+    {
+      path_name = filename;
+      fp = ::fopen(path_name.c_str(),"r");
+      if (fp != 0)
+        {
+	  fclose(fp);
+	  found = true;
+        }
+    }
+  
+  if (found == false)
+    return "";
+  
+  int loc = path_name.rfind('\\');
+  if (loc == -1)
+    {
+      loc = path_name.rfind('/');
+    }
+  
+  if (loc != -1)
+    file_path = path_name.substr(0, loc);
+  else
+    file_path = ".";
+  return file_path;
+}
+
+string data_path::get_file(std::string filename)
+{
+  FILE* fp;
+  
+  for(unsigned int i=0; i < path.size(); i++)
+    {
+      path_name = path[i] + "/" + filename;
+      fp = ::fopen(path_name.c_str(), "r");
+      
+      if(fp != 0)
+        {     
+	  fclose(fp);
+	  return path_name;
+        }
+    }
+  
+  path_name = filename;
+  fp = ::fopen(path_name.c_str(),"r");
+  if (fp != 0)
+    {
+      fclose(fp);
+      return path_name;
+    }
+  return "";
+}
+
+// data files, for read only
+FILE * data_path::fopen(std::string filename, const char * mode)
+{
+  
+  for(unsigned int i=0; i < path.size(); i++)
+    {
+      std::string s = path[i] + "/" + filename;
+      FILE * fp = ::fopen(s.c_str(), mode);
+      
+      if(fp != 0)
+	return fp;
+      else if (!strcmp(path[i].c_str(),""))
+	{
+	  FILE* fp = ::fopen(filename.c_str(),mode);
+	  if (fp != 0)
+	    return fp;
+	}
+    }
+  // no luck... return null
+  return 0;
+}
+
+//  fill the file stats structure 
+//  useful to get the file size and stuff
+int data_path::fstat(std::string filename, 
+#ifdef WIN32
+		     struct _stat 
+#else
+		     struct stat
+#endif
+		     * stat)
+{
+  for(unsigned int i=0; i < path.size(); i++)
+    {
+      std::string s = path[i] + "/" + filename;
+#ifdef WIN32
+      int fh = ::_open(s.c_str(), _O_RDONLY);
+#else
+      int fh = ::open(s.c_str(), O_RDONLY);
+#endif
+      if(fh >= 0)
+        {
+#ifdef WIN32
+	  int result = ::_fstat( fh, stat );
+#else
+	  int result = ::fstat (fh,stat);
+#endif
+	  if( result != 0 )
+            {
+	      fprintf( stderr, "An fstat error occurred.\n" );
+	      return 0;
+            }
+#ifdef WIN32
+	  ::_close( fh );
+#else
+	  ::close (fh);
+#endif
+	  return 1;
+    	}
+    }
+  // no luck...
+  return 0;
+}

--- a/qt/tileedit/extern/fastdxt/util.h
+++ b/qt/tileedit/extern/fastdxt/util.h
@@ -1,0 +1,108 @@
+/******************************************************************************
+ * Fast DXT - a realtime DXT compression tool
+ *
+ * Author : Luc Renambot
+ *
+ * Copyright (C) 2007 Electronic Visualization Laboratory,
+ * University of Illinois at Chicago
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either Version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ *****************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <vector>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#include <sys/time.h>
+#else
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#pragma warning(disable:4786)   // symbol size limitation ... STL
+#endif
+
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+
+#include <stdarg.h>
+//#include <values.h>
+
+
+void   aInitialize();
+
+double aTime();
+
+void   aLog(const char* format,...);
+void aError(const char* format,...);
+
+void* aAlloc(size_t const n);
+void aFree(void* const p);
+
+#if defined(WIN32)
+float drand48(void);
+#endif
+
+#if defined(__APPLE__)
+#define memalign(x,y) malloc((y))
+#else
+#include <malloc.h>
+#endif
+
+
+#if defined(WIN32)
+void *aligned_malloc(size_t size, size_t align_size);
+#define memalign(x,y) aligned_malloc(y, x)
+void aligned_free(void *ptr);
+#define memfree(x) aligned_free(x)
+#else
+#define memfree(x) free(x)
+#endif
+
+
+// From NVIDIA Toolkit
+
+#ifndef DATA_PATH_H
+#define DATA_PATH_H
+
+class data_path
+{
+public:
+  std::string              file_path;
+  std::string              path_name;
+  std::vector<std::string> path;
+  
+  std::string get_path(std::string filename);
+  std::string get_file(std::string filename);
+  
+  FILE *fopen(std::string filename, const char * mode = "rb");
+    
+#ifdef WIN32
+  int fstat(std::string filename, struct _stat * stat);
+#else
+  int fstat(std::string filename, struct stat * stat);
+#endif
+};
+
+#endif

--- a/qt/tileedit/fastdxt.props
+++ b/qt/tileedit/fastdxt.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <FastdxtDir>$(MSBuildThisFileDirectory)extern\fastdxt</FastdxtDir>
     <FastdxtIncludeDir>$(FastdxtDir)</FastdxtIncludeDir>
-    <FastdxtLibDir>$(FastdxtDir)\$(Configuration)</FastdxtLibDir>
+    <FastdxtLibDir>$(FastdxtDir)\$(Platform)\$(Configuration)</FastdxtLibDir>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>

--- a/qt/tileedit/fastdxt.props
+++ b/qt/tileedit/fastdxt.props
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <FastdxtDir>$(MSBuildThisFileDirectory)extern\fastdxt</FastdxtDir>
+    <FastdxtIncludeDir>$(FastdxtDir)</FastdxtIncludeDir>
+    <FastdxtLibDir>$(FastdxtDir)\$(Configuration)</FastdxtLibDir>
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <Link>
+      <AdditionalLibraryDirectories>$(FastdxtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>fastdxt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(FastdxtIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>
+      </PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="FastdxtDir">
+      <Value>$(FastdxtDir)</Value>
+    </BuildMacro>
+    <BuildMacro Include="FastdxtIncludeDir">
+      <Value>$(FastdxtIncludeDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="FastdxtLibDir">
+      <Value>$(FastdxtLibDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/qt/tileedit/tileedit.sln
+++ b/qt/tileedit/tileedit.sln
@@ -4,20 +4,41 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tileedit", "tileedit\tileedit.vcxproj", "{B12702AD-ABFB-343A-A199-8E24837244A3}"
+	ProjectSection(ProjectDependencies) = postProject
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047} = {9D0058F5-B01B-44EE-9B3F-5852E37C7047}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fastdxt", "extern\fastdxt\fastdxt.vcxproj", "{9D0058F5-B01B-44EE-9B3F-5852E37C7047}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release_static|x64 = Release_static|x64
+		Release_static|x86 = Release_static|x86
 		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x64.ActiveCfg = Debug|x64
 		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x64.Build.0 = Debug|x64
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x86.ActiveCfg = Debug|x64
 		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release_static|x64.ActiveCfg = Release_static|x64
 		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release_static|x64.Build.0 = Release_static|x64
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release_static|x86.ActiveCfg = Release_static|x64
 		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x64.ActiveCfg = Release|x64
 		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x64.Build.0 = Release|x64
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x86.ActiveCfg = Release|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Debug|x64.ActiveCfg = Debug|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Debug|x64.Build.0 = Debug|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Debug|x86.ActiveCfg = Debug|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Release_static|x64.ActiveCfg = Release|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Release_static|x64.Build.0 = Release|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Release_static|x86.ActiveCfg = Release|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Release_static|x86.Build.0 = Release|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Release|x64.ActiveCfg = Release|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Release|x64.Build.0 = Release|x64
+		{9D0058F5-B01B-44EE-9B3F-5852E37C7047}.Release|x86.ActiveCfg = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/qt/tileedit/tileedit/ddsread.cpp
+++ b/qt/tileedit/tileedit/ddsread.cpp
@@ -1,6 +1,5 @@
 #include <windows.h>
 #include <iostream>
-#include <vector>
 #include "ddsread.h"
 
 struct DDSPIXELFORMAT {
@@ -30,32 +29,6 @@ struct DDSHEADER {
     DWORD dwCaps4;
     DWORD dwReserved2;
 };
-
-Image &Image::operator=(const Image &img)
-{
-	data = img.data;
-	width = img.width;
-	height = img.height;
-	return *this;
-}
-
-Image Image::SubImage(const std::pair<DWORD,DWORD> &xrange, const std::pair<DWORD,DWORD> &yrange)
-{
-    Image sub;
-    sub.width = xrange.second - xrange.first;
-    sub.height = yrange.second - yrange.first;
-
-    sub.data.resize(sub.width * sub.height);
-
-    DWORD *imgptr = data.data();
-    DWORD *subptr = sub.data.data();
-    for (int y = 0; y < sub.height; y++) {
-        memcpy(subptr + y*sub.width, imgptr + (y+yrange.first)*width + xrange.first, sub.width*sizeof(DWORD));
-    }
-    return sub;
-}
-
-
 
 std::vector<DWORD> ExtractDXT1 (WORD *data, DWORD ndata, DWORD height, DWORD width);
 

--- a/qt/tileedit/tileedit/ddsread.h
+++ b/qt/tileedit/tileedit/ddsread.h
@@ -1,17 +1,9 @@
 #ifndef DDSREAD_H
 #define DDSREAD_H
 
-struct Image {
-    std::vector<DWORD> data;
-    DWORD width;
-    DWORD height;
-
-	Image() { width = height = 0; }
-	Image &operator=(const Image &img);
-    Image SubImage(const std::pair<DWORD,DWORD> &xrange, const std::pair<DWORD,DWORD> &yrange);
-};
+#include "imagetools.h"
 
 Image ddsread(const char *fname);
 Image ddsscan(const BYTE *data, int ndata);
 
-#endif // DDSREAD_H
+#endif // !DDSREAD_H

--- a/qt/tileedit/tileedit/dlgElevImport.ui
+++ b/qt/tileedit/tileedit/dlgElevImport.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>tileedit: Import</string>
+   <string>tileedit: Import elevation patch</string>
   </property>
   <widget class="QWidget" name="layoutWidget">
    <property name="geometry">

--- a/qt/tileedit/tileedit/dlgSurfImport.ui
+++ b/qt/tileedit/tileedit/dlgSurfImport.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>480</height>
+    <height>540</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>430</y>
+     <y>490</y>
      <width>351</width>
      <height>33</height>
     </rect>
@@ -270,7 +270,7 @@
     </rect>
    </property>
    <property name="title">
-    <string>Mode</string>
+    <string>Blending</string>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout_2">
     <item>
@@ -286,7 +286,7 @@
    <property name="geometry">
     <rect>
      <x>19</x>
-     <y>329</y>
+     <y>395</y>
      <width>361</width>
      <height>81</height>
     </rect>
@@ -348,6 +348,40 @@
         </spacer>
        </item>
       </layout>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QGroupBox" name="groupBox_4">
+   <property name="geometry">
+    <rect>
+     <x>19</x>
+     <y>329</y>
+     <width>361</width>
+     <height>53</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Colour matching</string>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout_4">
+    <item>
+     <widget class="QComboBox" name="comboColourmatch">
+      <item>
+       <property name="text">
+        <string>None</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Cumulative histogram</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Hue + saturation</string>
+       </property>
+      </item>
      </widget>
     </item>
    </layout>

--- a/qt/tileedit/tileedit/dlgSurfImport.ui
+++ b/qt/tileedit/tileedit/dlgSurfImport.ui
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgSurfImport</class>
+ <widget class="QDialog" name="DlgSurfImport">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>408</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>tileedit: Import surface patch</string>
+  </property>
+  <widget class="QWidget" name="layoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>360</y>
+     <width>351</width>
+     <height>33</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout">
+    <property name="spacing">
+     <number>6</number>
+    </property>
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <spacer>
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>131</width>
+        <height>31</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QPushButton" name="okButton">
+      <property name="text">
+       <string>OK</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="cancelButton">
+      <property name="text">
+       <string>Cancel</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>19</x>
+     <y>19</y>
+     <width>361</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Path:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLineEdit" name="editPath"/>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pushOpenFileDialog">
+      <property name="minimumSize">
+       <size>
+        <width>25</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>25</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QGroupBox" name="groupBox">
+   <property name="geometry">
+    <rect>
+     <x>19</x>
+     <y>59</y>
+     <width>361</width>
+     <height>198</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Image range</string>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QRadioButton" name="radioParamFromMeta">
+      <property name="text">
+       <string>From metafile:</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QWidget" name="widgetParamMeta" native="true">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <property name="leftMargin">
+        <number>20</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLineEdit" name="editMetaPath"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushOpenMetaFileDialog">
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>25</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QRadioButton" name="radioParamFromUser">
+      <property name="text">
+       <string>From tile indices:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QWidget" name="widgetParamUser" native="true">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="leftMargin">
+        <number>20</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Resolution:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Latitude index range:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QSpinBox" name="spinIlat1">
+         <property name="maximum">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QSpinBox" name="spinIlng1">
+         <property name="maximum">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QSpinBox" name="spinIlng0">
+         <property name="maximum">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Longitude index range:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="spinLvl">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>19</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QSpinBox" name="spinIlat0">
+         <property name="maximum">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>okButton</sender>
+   <signal>clicked()</signal>
+   <receiver>DlgSurfImport</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>278</x>
+     <y>253</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>96</x>
+     <y>254</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cancelButton</sender>
+   <signal>clicked()</signal>
+   <receiver>DlgSurfImport</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>369</x>
+     <y>253</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>282</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/qt/tileedit/tileedit/dlgSurfImport.ui
+++ b/qt/tileedit/tileedit/dlgSurfImport.ui
@@ -260,6 +260,28 @@
     </item>
    </layout>
   </widget>
+  <widget class="QGroupBox" name="groupBox_2">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>269</y>
+     <width>361</width>
+     <height>50</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Mode</string>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout_2">
+    <item>
+     <widget class="QCheckBox" name="checkAlphaBlend">
+      <property name="text">
+       <string>Use alpha channel to blend with background</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
  </widget>
  <resources/>
  <connections>

--- a/qt/tileedit/tileedit/dlgSurfImport.ui
+++ b/qt/tileedit/tileedit/dlgSurfImport.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>408</height>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>360</y>
+     <y>430</y>
      <width>351</width>
      <height>33</height>
     </rect>
@@ -278,6 +278,76 @@
       <property name="text">
        <string>Use alpha channel to blend with background</string>
       </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QGroupBox" name="groupBox_3">
+   <property name="geometry">
+    <rect>
+     <x>19</x>
+     <y>329</y>
+     <width>361</width>
+     <height>81</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Propagation</string>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout_3">
+    <item>
+     <widget class="QCheckBox" name="checkPropagateChanges">
+      <property name="text">
+       <string>Propagate changes to lower resolution levels</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QWidget" name="widgetPropagateChanges" native="true">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <property name="leftMargin">
+        <number>20</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>down to level</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinPropagationLevel">
+         <property name="minimum">
+          <number>4</number>
+         </property>
+         <property name="maximum">
+          <number>19</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </widget>
     </item>
    </layout>

--- a/qt/tileedit/tileedit/dlgelevimport.cpp
+++ b/qt/tileedit/tileedit/dlgelevimport.cpp
@@ -216,7 +216,7 @@ void DlgElevImport::accept()
 			}
 		}
 	if (m_propagationLevel) {
-		eblock->MatchParentTiles(m_propagationLevel);
+		eblock->mapToAncestors(m_propagationLevel);
 	}
 
 	QDialog::accept();

--- a/qt/tileedit/tileedit/dlgelevimport.cpp
+++ b/qt/tileedit/tileedit/dlgelevimport.cpp
@@ -23,7 +23,7 @@ DlgElevImport::DlgElevImport(tileedit *parent)
 	m_pathEdited = m_metaEdited = false;
 	m_haveMeta = false;
 	m_propagationLevel = ui->spinPropagationLevel->value();
-	memset(&m_metaInfo, 0, sizeof(ImageMetaInfo));
+	memset(&m_metaInfo, 0, sizeof(ElevPatchMetaInfo));
 }
 
 void DlgElevImport::onOpenFileDialog()
@@ -76,7 +76,7 @@ void DlgElevImport::onMetaFileChanged(const QString &name)
 		ui->spinIlng1->setMaximum(m_metaInfo.ilng1 - 1);
 	}
 	else {
-		memset(&m_metaInfo, 0, sizeof(ImageMetaInfo));
+		memset(&m_metaInfo, 0, sizeof(ElevPatchMetaInfo));
 		ui->labelLvl->setText("-");
 		ui->spinIlat0->setValue(0);
 		ui->spinIlat1->setValue(0);
@@ -114,7 +114,7 @@ void DlgElevImport::onPropagateChanges(int state)
 	ui->widgetPropagateChanges->setEnabled(state == Qt::Checked);
 }
 
-bool DlgElevImport::scanMetaFile(const char *fname, ImageMetaInfo &meta)
+bool DlgElevImport::scanMetaFile(const char *fname, ElevPatchMetaInfo &meta)
 {
 	FILE *f = fopen(fname, "rt");
 	if (!f) return false;
@@ -200,7 +200,7 @@ void DlgElevImport::accept()
 
 	for (int ilat = ilat0; ilat < ilat1; ilat++)
 		for (int ilng = ilng0; ilng < ilng1; ilng++) {
-			eblock->SyncTile(ilat, ilng);
+			eblock->syncTile(ilat, ilng);
 			ElevTile *etile = (ElevTile*)eblock->_getTile(ilat, ilng);
 			if (etile->Level() == etile->subLevel())
 				etile->SaveMod();

--- a/qt/tileedit/tileedit/dlgelevimport.h
+++ b/qt/tileedit/tileedit/dlgelevimport.h
@@ -28,7 +28,7 @@ public slots:
 	void accept();
 
 protected:
-	bool scanMetaFile(const char *fname, ImageMetaInfo &meta);
+	bool scanMetaFile(const char *fname, ElevPatchMetaInfo &meta);
 
 private:
 	Ui::DlgElevImport *ui;
@@ -36,7 +36,7 @@ private:
 	bool m_pathEdited, m_metaEdited;
 	bool m_haveMeta;
 	int m_propagationLevel;
-	ImageMetaInfo m_metaInfo;
+	ElevPatchMetaInfo m_metaInfo;
 };
 
 #endif // !DLGELEVIMPORT_H

--- a/qt/tileedit/tileedit/dlgsurfimport.cpp
+++ b/qt/tileedit/tileedit/dlgsurfimport.cpp
@@ -112,6 +112,7 @@ void DlgSurfImport::accept()
 			return;
 		}
 	}
+	m_metaInfo.alphaBlend = ui->checkAlphaBlend->isChecked();
 
 	SurfTileBlock *sblock = SurfTileBlock::Load(m_metaInfo.lvl, m_metaInfo.ilat0, m_metaInfo.ilat1, m_metaInfo.ilng0, m_metaInfo.ilng1);
 	int res = dxtread_png(ui->editPath->text().toLatin1(), m_metaInfo, sblock->getData());

--- a/qt/tileedit/tileedit/dlgsurfimport.cpp
+++ b/qt/tileedit/tileedit/dlgsurfimport.cpp
@@ -19,9 +19,11 @@ DlgSurfImport::DlgSurfImport(tileedit *parent)
 	connect(ui->radioParamFromUser, SIGNAL(clicked()), this, SLOT(onParamFromUser()));
 	connect(ui->editMetaPath, SIGNAL(textChanged(const QString&)), this, SLOT(onMetaFileChanged(const QString&)));
 	connect(ui->spinLvl, SIGNAL(valueChanged(int)), this, SLOT(onLvl(int)));
+	connect(ui->checkPropagateChanges, SIGNAL(stateChanged(int)), this, SLOT(onPropagateChanges(int)));
 
 	m_pathEdited = m_metaEdited = false;
 	m_haveMeta = false;
+	m_propagationLevel = ui->spinPropagationLevel->value();
 	memset(&m_metaInfo, 0, sizeof(SurfPatchMetaInfo));
 }
 
@@ -76,7 +78,7 @@ void DlgSurfImport::onMetaFileChanged(const QString &name)
 		ui->spinIlat0->setValue(m_metaInfo.ilat0);
 		ui->spinIlat1->setValue(m_metaInfo.ilat1 - 1);
 		ui->spinIlng0->setValue(m_metaInfo.ilng0);
-		ui->spinIlng1->setValue(m_metaInfo.ilng1);
+		ui->spinIlng1->setValue(m_metaInfo.ilng1 - 1);
 	}
 	else {
 		memset(&m_metaInfo, 0, sizeof(SurfPatchMetaInfo));
@@ -92,8 +94,16 @@ void DlgSurfImport::onLvl(int val)
 {
 	int nlat = nLat(val);
 	int nlng = nLng(val);
+	ui->spinIlat0->setMaximum(nlat - 1);
 	ui->spinIlat1->setMaximum(nlat - 1);
+	ui->spinIlng0->setMaximum(nlng - 1);
 	ui->spinIlng1->setMaximum(nlng - 1);
+}
+
+void DlgSurfImport::onPropagateChanges(int state)
+{
+	m_propagationLevel = (state == Qt::Checked ? ui->spinPropagationLevel->value() : 0);
+	ui->widgetPropagateChanges->setEnabled(state == Qt::Checked);
 }
 
 void DlgSurfImport::accept()
@@ -145,7 +155,10 @@ void DlgSurfImport::accept()
 				stile->Save();
 			// ...
 		}
-
+	if (m_propagationLevel) {
+		sblock->mapToAncestors(m_propagationLevel);
+	}
+	
 	QDialog::accept();
 }
 

--- a/qt/tileedit/tileedit/dlgsurfimport.cpp
+++ b/qt/tileedit/tileedit/dlgsurfimport.cpp
@@ -1,0 +1,125 @@
+#include "dlgsurfimport.h"
+#include "ui_dlgSurfImport.h"
+#include "tileedit.h"
+#include "tileblock.h"
+
+#include <QMessageBox>
+
+DlgSurfImport::DlgSurfImport(tileedit *parent)
+	: QDialog(parent)
+	, ui(new Ui::DlgSurfImport)
+{
+	ui->setupUi(this);
+
+	connect(ui->radioParamFromMeta, SIGNAL(clicked()), this, SLOT(onParamFromMeta()));
+	connect(ui->radioParamFromUser, SIGNAL(clicked()), this, SLOT(onParamFromUser()));
+	connect(ui->editMetaPath, SIGNAL(textChanged(const QString&)), this, SLOT(onMetaFileChanged(const QString&)));
+	connect(ui->spinLvl, SIGNAL(valueChanged(int)), this, SLOT(onLvl(int)));
+
+	m_haveMeta = false;
+	memset(&m_metaInfo, 0, sizeof(SurfPatchMetaInfo));
+}
+
+void DlgSurfImport::onParamFromMeta()
+{
+	ui->widgetParamMeta->setEnabled(true);
+	ui->widgetParamUser->setEnabled(false);
+}
+
+void DlgSurfImport::onParamFromUser()
+{
+	ui->widgetParamMeta->setEnabled(false);
+	ui->widgetParamUser->setEnabled(true);
+}
+
+void DlgSurfImport::onMetaFileChanged(const QString &name)
+{
+	m_haveMeta = scanMetaFile(name.toLatin1(), m_metaInfo);
+	if (m_haveMeta) {
+		ui->spinLvl->setValue(m_metaInfo.lvl);
+		ui->spinIlat0->setValue(m_metaInfo.ilat0);
+		ui->spinIlat1->setValue(m_metaInfo.ilat1 - 1);
+		ui->spinIlng0->setValue(m_metaInfo.ilng0);
+		ui->spinIlng1->setValue(m_metaInfo.ilng1);
+	}
+	else {
+		memset(&m_metaInfo, 0, sizeof(SurfPatchMetaInfo));
+		ui->spinLvl->setValue(1);
+		ui->spinIlat0->setValue(0);
+		ui->spinIlat1->setValue(0);
+		ui->spinIlng0->setValue(0);
+		ui->spinIlng1->setValue(0);
+	}
+}
+
+void DlgSurfImport::onLvl(int val)
+{
+	int nlat = nLat(val);
+	int nlng = nLng(val);
+	ui->spinIlat1->setMaximum(nlat - 1);
+	ui->spinIlng1->setMaximum(nlng - 1);
+}
+
+void DlgSurfImport::accept()
+{
+	if (ui->radioParamFromUser->isChecked()) {
+		m_metaInfo.lvl = ui->spinLvl->value();
+		m_metaInfo.ilat0 = ui->spinIlat0->value();
+		m_metaInfo.ilat1 = ui->spinIlat1->value() + 1;
+		m_metaInfo.ilng0 = ui->spinIlng0->value();
+		m_metaInfo.ilng1 = ui->spinIlng1->value() + 1;
+	}
+	else {
+		if (!m_haveMeta) {
+			QMessageBox mbox(QMessageBox::Warning, tr("tileedit: Warning"), tr("No valid metadata information is available"), QMessageBox::Close);
+			mbox.exec();
+			return;
+		}
+	}
+
+	SurfTileBlock *sblock = SurfTileBlock::Load(m_metaInfo.lvl, m_metaInfo.ilat0, m_metaInfo.ilat1, m_metaInfo.ilng0, m_metaInfo.ilng1);
+	if (!dxtread_png(ui->editPath->text().toLatin1(), m_metaInfo, sblock->getData())) {
+		QMessageBox mbox(QMessageBox::Warning, tr("tileedit: Warning"), tr("Error reading PNG file"), QMessageBox::Close);
+		mbox.exec();
+		return;
+	}
+
+	for (int ilat = m_metaInfo.ilat0; ilat < m_metaInfo.ilat1; ilat++)
+		for (int ilng = m_metaInfo.ilng0; ilng < m_metaInfo.ilng1; ilng++) {
+			sblock->syncTile(ilat, ilng);
+			SurfTile *stile = (SurfTile*)sblock->_getTile(ilat, ilng);
+			if (stile->Level() == stile->subLevel())
+				stile->Save();
+			// ...
+		}
+
+	QDialog::accept();
+}
+
+bool DlgSurfImport::scanMetaFile(const char *fname, SurfPatchMetaInfo &meta)
+{
+	FILE *f = fopen(fname, "rt");
+	if (!f) return false;
+
+	int ilat, ilng, n;
+	char str[1024];
+	if (fscanf(f, "lvl=%d ilat0=%d ilat1=%d ilng0=%d ilng1=%d\n",
+		&meta.lvl, &meta.ilat0, &meta.ilat1, &meta.ilng0, &meta.ilng1) != 5) {
+		meta.lvl = meta.ilat0 = meta.ilat1 = meta.ilng0 = meta.ilng1 = 0;
+	}
+	else {
+		fscanf(f, "%s", str);
+		if (!strncmp(str, "missing", 7)) {
+			while (true) {
+				n = fscanf(f, "%d/%d", &ilat, &ilng);
+				if (n == 2) {
+					meta.missing.push_back(std::make_pair(ilat, ilng));
+				}
+				else
+					break;
+			}
+		}
+	}
+	fclose(f);
+	return true;
+}

--- a/qt/tileedit/tileedit/dlgsurfimport.cpp
+++ b/qt/tileedit/tileedit/dlgsurfimport.cpp
@@ -123,6 +123,7 @@ void DlgSurfImport::accept()
 		}
 	}
 	m_metaInfo.alphaBlend = ui->checkAlphaBlend->isChecked();
+	m_metaInfo.colourMatch = ui->comboColourmatch->currentIndex();
 
 	SurfTileBlock *sblock = SurfTileBlock::Load(m_metaInfo.lvl, m_metaInfo.ilat0, m_metaInfo.ilat1, m_metaInfo.ilng0, m_metaInfo.ilng1);
 	int res = dxtread_png(ui->editPath->text().toLatin1(), m_metaInfo, sblock->getData());

--- a/qt/tileedit/tileedit/dlgsurfimport.cpp
+++ b/qt/tileedit/tileedit/dlgsurfimport.cpp
@@ -14,6 +14,7 @@ DlgSurfImport::DlgSurfImport(tileedit *parent)
 	ui->setupUi(this);
 
 	connect(ui->pushOpenFileDialog, SIGNAL(clicked()), this, SLOT(onOpenFileDialog()));
+	connect(ui->pushOpenMetaFileDialog, SIGNAL(clicked()), this, SLOT(onOpenMetaFileDialog()));
 	connect(ui->radioParamFromMeta, SIGNAL(clicked()), this, SLOT(onParamFromMeta()));
 	connect(ui->radioParamFromUser, SIGNAL(clicked()), this, SLOT(onParamFromUser()));
 	connect(ui->editMetaPath, SIGNAL(textChanged(const QString&)), this, SLOT(onMetaFileChanged(const QString&)));
@@ -39,6 +40,19 @@ void DlgSurfImport::onOpenFileDialog()
 			ui->editMetaPath->setText(path);
 		}
 		m_pathEdited = true;
+	}
+}
+
+void DlgSurfImport::onOpenMetaFileDialog()
+{
+	QString path = QFileDialog::getOpenFileName(this, tr("Import surface tiles from image file"), ui->editMetaPath->text(), tr("Metadata file (*.hdr)"));
+	if (path.size()) {
+		ui->editMetaPath->setText(path);
+		if (!m_pathEdited) {
+			path.truncate(path.length() - 4);
+			ui->editPath->setText(path);
+		}
+		m_metaEdited = true;
 	}
 }
 

--- a/qt/tileedit/tileedit/dlgsurfimport.h
+++ b/qt/tileedit/tileedit/dlgsurfimport.h
@@ -24,6 +24,7 @@ public slots:
 	void onParamFromUser();
 	void onMetaFileChanged(const QString&);
 	void onLvl(int);
+	void onPropagateChanges(int);
 	void accept();
 
 protected:
@@ -35,6 +36,7 @@ private:
 	SurfPatchMetaInfo m_metaInfo;
 	bool m_pathEdited, m_metaEdited;
 	bool m_haveMeta;
+	int m_propagationLevel;
 };
 
 #endif // !DLGSURFIMPORT_H

--- a/qt/tileedit/tileedit/dlgsurfimport.h
+++ b/qt/tileedit/tileedit/dlgsurfimport.h
@@ -19,6 +19,7 @@ public:
 
 public slots:
 	void onOpenFileDialog();
+	void onOpenMetaFileDialog();
 	void onParamFromMeta();
 	void onParamFromUser();
 	void onMetaFileChanged(const QString&);

--- a/qt/tileedit/tileedit/dlgsurfimport.h
+++ b/qt/tileedit/tileedit/dlgsurfimport.h
@@ -18,6 +18,7 @@ public:
 	DlgSurfImport(tileedit *parent);
 
 public slots:
+	void onOpenFileDialog();
 	void onParamFromMeta();
 	void onParamFromUser();
 	void onMetaFileChanged(const QString&);
@@ -29,7 +30,9 @@ protected:
 
 private:
 	Ui::DlgSurfImport *ui;
+	tileedit *m_tileedit;
 	SurfPatchMetaInfo m_metaInfo;
+	bool m_pathEdited, m_metaEdited;
 	bool m_haveMeta;
 };
 

--- a/qt/tileedit/tileedit/dlgsurfimport.h
+++ b/qt/tileedit/tileedit/dlgsurfimport.h
@@ -1,0 +1,36 @@
+#ifndef DLGSURFIMPORT_H
+#define DLGSURFIMPORT_H
+
+#include "dxt_io.h"
+#include <QDialog>
+
+namespace Ui {
+	class DlgSurfImport;
+}
+
+class tileedit;
+
+class DlgSurfImport : public QDialog
+{
+	Q_OBJECT
+
+public:
+	DlgSurfImport(tileedit *parent);
+
+public slots:
+	void onParamFromMeta();
+	void onParamFromUser();
+	void onMetaFileChanged(const QString&);
+	void onLvl(int);
+	void accept();
+
+protected:
+	bool scanMetaFile(const char *fname, SurfPatchMetaInfo &meta);
+
+private:
+	Ui::DlgSurfImport *ui;
+	SurfPatchMetaInfo m_metaInfo;
+	bool m_haveMeta;
+};
+
+#endif // !DLGSURFIMPORT_H

--- a/qt/tileedit/tileedit/dxt_io.cpp
+++ b/qt/tileedit/tileedit/dxt_io.cpp
@@ -1,0 +1,100 @@
+#include "dxt_io.h"
+#include <png.h>
+#include <libdxt.h>
+
+struct DDS_PIXELFORMAT {
+	DWORD dwSize;
+	DWORD dwFlags;
+	DWORD dwFourCC;
+	DWORD dwRGBBitCount;
+	DWORD dwRBitMask;
+	DWORD dwGBitMask;
+	DWORD dwBBitMask;
+	DWORD dwABitMask;
+};
+
+struct DDS_HEADER{
+	DWORD           dwSize;
+	DWORD           dwFlags;
+	DWORD           dwHeight;
+	DWORD           dwWidth;
+	DWORD           dwPitchOrLinearSize;
+	DWORD           dwDepth;
+	DWORD           dwMipMapCount;
+	DWORD           dwReserved1[11];
+	DDS_PIXELFORMAT ddspf;
+	DWORD           dwCaps;
+	DWORD           dwCaps2;
+	DWORD           dwCaps3;
+	DWORD           dwCaps4;
+	DWORD           dwReserved2;
+};
+
+void setdxt1header(const Image &idata, DDS_HEADER &hdr)
+{
+	const char fourcc[4] = { 'D', 'X', 'T', '1' };
+
+	memset(&hdr, 0, sizeof(DDS_HEADER));
+	hdr.dwSize = sizeof(DDS_HEADER);
+	hdr.dwFlags = 0x00081007;
+	hdr.dwHeight = idata.height;
+	hdr.dwWidth = idata.width;
+	hdr.dwPitchOrLinearSize = idata.height * idata.width / 2;
+	hdr.ddspf.dwSize = sizeof(DDS_PIXELFORMAT);
+	hdr.ddspf.dwFlags = 0x4;
+	hdr.ddspf.dwFourCC = *(DWORD*)fourcc;
+	hdr.dwCaps = 0x1000;
+}
+
+void dxt1write(const char *fname, const Image &idata)
+{
+	const char magic[4] = { 'D', 'D', 'S', ' ' };
+	int format = FORMAT_DXT1;
+	byte *dxt1 = new byte[idata.width * idata.height * 4];
+	int n = CompressDXT((const byte*)idata.data.data(), dxt1, idata.width, idata.height, format);
+
+	DDS_HEADER hdr;
+	setdxt1header(idata, hdr);
+	FILE *f = fopen(fname, "wb");
+	fwrite(magic, 1, 4, f);
+	fwrite(&hdr, sizeof(DDS_HEADER), 1, f);
+	fwrite(dxt1, n, 1, f);
+	fclose(f);
+	delete[]dxt1;
+}
+
+bool dxtread_png(const char *fname, const SurfPatchMetaInfo &meta, Image &sdata)
+{
+	bool ok = false;
+	png_image image;
+	memset(&image, 0, sizeof(png_image));
+	image.version = PNG_IMAGE_VERSION;
+	image.opaque = NULL;
+	if (png_image_begin_read_from_file(&image, fname)) {
+		image.format = PNG_FORMAT_RGB;
+
+		int nblock_x = meta.ilng1 - meta.ilng0;
+		int nblock_y = meta.ilat1 - meta.ilat0;
+		int w = nblock_x * TILE_SURFSTRIDE;
+		int h = nblock_y * TILE_SURFSTRIDE;
+		if (image.width == w || image.height == h) {
+
+			int n = w*h;
+			unsigned char *buf = new unsigned char[n * 3];
+			png_image_finish_read(&image, NULL, buf, w * 3, NULL);
+
+			int idx = 0;
+			for (int ih = 0; ih < h; ih++) {
+				for (int iw = 0; iw < w; iw++) {
+					DWORD v = 0xff000000 | (buf[idx + 2] << 16) | (buf[idx + 1] << 8) | buf[idx];
+					sdata.data[iw + ih*w] = v;
+					idx += 3;
+				}
+			}
+			delete[]buf;
+			ok = true;
+		}
+	}
+	png_image_free(&image);
+	return ok;
+}

--- a/qt/tileedit/tileedit/dxt_io.cpp
+++ b/qt/tileedit/tileedit/dxt_io.cpp
@@ -63,9 +63,9 @@ void dxt1write(const char *fname, const Image &idata)
 	delete[]dxt1;
 }
 
-bool dxtread_png(const char *fname, const SurfPatchMetaInfo &meta, Image &sdata)
+int dxtread_png(const char *fname, const SurfPatchMetaInfo &meta, Image &sdata)
 {
-	bool ok = false;
+	int res = 0;
 	png_image image;
 	memset(&image, 0, sizeof(png_image));
 	image.version = PNG_IMAGE_VERSION;
@@ -73,11 +73,9 @@ bool dxtread_png(const char *fname, const SurfPatchMetaInfo &meta, Image &sdata)
 	if (png_image_begin_read_from_file(&image, fname)) {
 		image.format = PNG_FORMAT_RGB;
 
-		int nblock_x = meta.ilng1 - meta.ilng0;
-		int nblock_y = meta.ilat1 - meta.ilat0;
-		int w = nblock_x * TILE_SURFSTRIDE;
-		int h = nblock_y * TILE_SURFSTRIDE;
-		if (image.width == w || image.height == h) {
+		int w = sdata.width;
+		int h = sdata.height;
+		if (image.width == w && image.height == h) {
 
 			int n = w*h;
 			unsigned char *buf = new unsigned char[n * 3];
@@ -92,9 +90,14 @@ bool dxtread_png(const char *fname, const SurfPatchMetaInfo &meta, Image &sdata)
 				}
 			}
 			delete[]buf;
-			ok = true;
+		}
+		else {
+			res = -2;
 		}
 	}
+	else {
+		res = -1;
+	}
 	png_image_free(&image);
-	return ok;
+	return res;
 }

--- a/qt/tileedit/tileedit/dxt_io.h
+++ b/qt/tileedit/tileedit/dxt_io.h
@@ -13,6 +13,6 @@ struct SurfPatchMetaInfo
 
 void dxt1write(const char *fname, const Image &idata);
 
-bool dxtread_png(const char *fname, const SurfPatchMetaInfo &meta, Image &sdata);
+int dxtread_png(const char *fname, const SurfPatchMetaInfo &meta, Image &sdata);
 
 #endif // !DXT_IO_H

--- a/qt/tileedit/tileedit/dxt_io.h
+++ b/qt/tileedit/tileedit/dxt_io.h
@@ -1,0 +1,18 @@
+#ifndef DXT_IO_H
+#define DXT_IO_H
+
+#include "tile.h"
+
+struct SurfPatchMetaInfo
+{
+	int lvl;
+	int ilat0, ilat1, ilng0, ilng1;
+	double latmin, latmax, lngmin, lngmax;
+	std::vector<std::pair<int, int> > missing;
+};
+
+void dxt1write(const char *fname, const Image &idata);
+
+bool dxtread_png(const char *fname, const SurfPatchMetaInfo &meta, Image &sdata);
+
+#endif // !DXT_IO_H

--- a/qt/tileedit/tileedit/dxt_io.h
+++ b/qt/tileedit/tileedit/dxt_io.h
@@ -9,6 +9,7 @@ struct SurfPatchMetaInfo
 	int ilat0, ilat1, ilng0, ilng1;
 	double latmin, latmax, lngmin, lngmax;
 	std::vector<std::pair<int, int> > missing;
+	bool alphaBlend;
 };
 
 void dxt1write(const char *fname, const Image &idata);

--- a/qt/tileedit/tileedit/dxt_io.h
+++ b/qt/tileedit/tileedit/dxt_io.h
@@ -10,6 +10,7 @@ struct SurfPatchMetaInfo
 	double latmin, latmax, lngmin, lngmax;
 	std::vector<std::pair<int, int> > missing;
 	bool alphaBlend;
+	int colourMatch;
 };
 
 void dxt1write(const char *fname, const Image &idata);

--- a/qt/tileedit/tileedit/elevtile.cpp
+++ b/qt/tileedit/tileedit/elevtile.cpp
@@ -331,7 +331,7 @@ void ElevTile::MatchNeighbourTiles()
 	}
 }
 
-bool ElevTile::MatchParentTile(int minlvl) const
+bool ElevTile::mapToAncestors(int minlvl) const
 {
 	const double eps = 1e-6;
 
@@ -374,7 +374,7 @@ bool ElevTile::MatchParentTile(int minlvl) const
 	if (isModified) {
 		etile->dataChanged();
 		etile->SaveMod();
-		etile->MatchParentTile(minlvl); // recursively propagate changes down the quadtree
+		etile->mapToAncestors(minlvl); // recursively propagate changes down the quadtree
 	}
 	delete etile;
 

--- a/qt/tileedit/tileedit/elevtile.cpp
+++ b/qt/tileedit/tileedit/elevtile.cpp
@@ -246,7 +246,7 @@ void ElevTile::Save()
 		double lngmax = lngmin + 2.0*M_PI / nlng;
 		RescanLimits();
 
-		ensureLayerDir(s_root.c_str(), Layer().c_str(), m_lvl, m_ilat);
+		ensureLayerDir();
 		elvwrite(path, m_edata, latmin, latmax, lngmin, lngmax);
 		m_modified = false;
 	}
@@ -257,7 +257,7 @@ void ElevTile::SaveMod()
 	if (m_modified) {
 		char path[1024];
 		sprintf(path, "%s_mod", Layer().c_str());
-		ensureLayerDir(s_root.c_str(), path, m_lvl, m_ilat);
+		::ensureLayerDir(s_root.c_str(), path, m_lvl, m_ilat);
 		sprintf(path, "%s/%s_mod/%02d/%06d/%06d.elv", s_root.c_str(), Layer().c_str(), m_lvl, m_ilat, m_ilng);
 		int nlat = (m_lvl < 4 ? 1 : 1 << (m_lvl - 4));
 		int nlng = (m_lvl < 4 ? 1 : 1 << (m_lvl - 3));
@@ -430,7 +430,7 @@ ElevTileBlock ElevTile::Prolong()
 			}
 		}
 	}
-	tblock.SyncTiles();
+	tblock.syncTiles();
 	for (int ilat = ilat0; ilat < ilat1; ilat++) {
 		for (int ilng = ilng0; ilng < ilng1; ilng++) {
 			Tile *tile = tblock._getTile(ilat, ilng);

--- a/qt/tileedit/tileedit/elevtile.h
+++ b/qt/tileedit/tileedit/elevtile.h
@@ -61,7 +61,7 @@ public:
 	void Save();
 	void SaveMod();
 	void MatchNeighbourTiles();
-	bool MatchParentTile(int minlvl) const;
+	bool mapToAncestors(int minlvl) const;
 
 	/**
 	 * \brief Interpolate the tile to the next resolution level

--- a/qt/tileedit/tileedit/elv_io.cpp
+++ b/qt/tileedit/tileedit/elv_io.cpp
@@ -1,5 +1,4 @@
 #include <windows.h>
-#include <direct.h>
 #include <vector>
 #include <algorithm>
 #define _USE_MATH_DEFINES
@@ -395,7 +394,7 @@ void elvmodwrite(const char *fname, const ElevData &edata, const ElevData &ebase
 
 // ==================================================================================
 
-bool elvread_png(const char *fname, const ImageMetaInfo &meta, ElevData &edata)
+bool elvread_png(const char *fname, const ElevPatchMetaInfo &meta, ElevData &edata)
 {
 	bool ok = false;
 	png_image image;
@@ -468,17 +467,4 @@ void elvwrite_png(const char *fname, const ElevData &edata, double vmin, double 
 	png_image_write_to_file(&image, fname, 0, buf, 0, 0);
 	png_image_free(&image);
 	delete[]buf;
-}
-
-// ==================================================================================
-
-void ensureLayerDir(const char *rootDir, const char *layer, int lvl, int ilat)
-{
-	char path[256];
-	sprintf(path, "%s/%s", rootDir, layer);
-	mkdir(path);
-	sprintf(path, "%s/%s/%02d", rootDir, layer, lvl);
-	mkdir(path);
-	sprintf(path, "%s/%s/%02d/%06d", rootDir, layer, lvl, ilat);
-	mkdir(path);
 }

--- a/qt/tileedit/tileedit/elv_io.h
+++ b/qt/tileedit/tileedit/elv_io.h
@@ -3,7 +3,7 @@
 
 #include "elevtile.h"
 
-struct ImageMetaInfo
+struct ElevPatchMetaInfo
 {
 	int lvl;
 	int ilat0, ilat1, ilng0, ilng1;
@@ -24,9 +24,7 @@ bool elvmodscan(const BYTE *data, int ndata, ElevData &edata);
 void elvwrite(const char *fname, const ElevData &edata, double latmin, double latmax, double lngmin, double lngmax);
 void elvmodwrite(const char *fname, const ElevData &edata, const ElevData &ebasedata, double latmin, double latmax, double lngmin, double lngmax);
 
-bool elvread_png(const char *fname, const ImageMetaInfo &meta, ElevData &edata);
+bool elvread_png(const char *fname, const ElevPatchMetaInfo &meta, ElevData &edata);
 void elvwrite_png(const char *fname, const ElevData &edata, double vmin, double vmax);
-
-void ensureLayerDir(const char *rootDir, const char *layer, int lvl, int ilat);
 
 #endif // !ELV_IO_H

--- a/qt/tileedit/tileedit/imagetools.cpp
+++ b/qt/tileedit/tileedit/imagetools.cpp
@@ -1,0 +1,81 @@
+#include "imagetools.h"
+#include <QColor>
+
+Image &Image::operator=(const Image &img)
+{
+	data = img.data;
+	width = img.width;
+	height = img.height;
+	return *this;
+}
+
+Image Image::SubImage(const std::pair<DWORD, DWORD> &xrange, const std::pair<DWORD, DWORD> &yrange)
+{
+	Image sub;
+	sub.width = xrange.second - xrange.first;
+	sub.height = yrange.second - yrange.first;
+
+	sub.data.resize(sub.width * sub.height);
+
+	DWORD *imgptr = data.data();
+	DWORD *subptr = sub.data.data();
+	for (int y = 0; y < sub.height; y++) {
+		memcpy(subptr + y*sub.width, imgptr + (y + yrange.first)*width + xrange.first, sub.width * sizeof(DWORD));
+	}
+	return sub;
+}
+
+void match_histogram(Image &im1, const Image &im2)
+{
+	int n = im1.width * im1.height;
+	for (int ch = 0; ch < 3; ch++) {
+		DWORD hist[256];
+		memset(hist, 0, 256 * sizeof(DWORD));
+		for (int i = 0; i < n; i++) { // construct histogram
+			DWORD v = (im2.data[i] >> (ch * 8)) & 0xff;
+			hist[v]++;
+		}
+		for (int i = 1; i < 256; i++) // cumulative
+			hist[i] += hist[i - 1];
+		for (int i = 0; i < 256; i++) // normalise
+			hist[i] = (hist[i] * 255) / n;
+
+		DWORD ihist[256]; // invert
+		for (int i = 0; i < 255; i++) {
+			DWORD v1 = hist[i];
+			DWORD v2 = hist[i + 1];
+			for (int j = v1; j < v2; j++)
+				ihist[j] = i;
+		}
+		for (int j = 0; j < hist[0]; j++)
+			ihist[j] = 0;
+		for (int j = hist[255]; j < 256; j++)
+			ihist[j] = 255;
+
+		// apply histogram to im1
+		DWORD mask = ~(0xff << (ch * 8));
+		for (int i = 0; i < n; i++) {
+			DWORD v = (im1.data[i] >> (ch * 8)) & 0xff;
+			DWORD vn = ihist[v];
+			im1.data[i] &= mask;
+			im1.data[i] |= vn << (ch * 8);
+		}
+	}
+}
+
+void match_hue_sat(Image &im1, const Image &im2)
+{
+	int n = im1.width * im1.height;
+	for (int i = 0; i < n; i++) {
+		DWORD p1 = im1.data[i];
+		DWORD p2 = im2.data[i];
+		QColor c1((p1 >> 16) & 0xff, (p1 >> 8) & 0xff, p1 & 0xff);
+		QColor c2((p2 >> 16) & 0xff, (p2 >> 8) & 0xff, p2 & 0xff);
+		int h1, s1, v1, h2, s2, v2;
+		c1.getHsv(&h1, &s1, &v1);
+		c2.getHsv(&h2, &s2, &v2);
+		c1.setHsv(h2, s2, v1);
+		p1 = 0xff000000 | (c1.red() << 16) | (c1.green() << 8) | c1.blue();
+		im1.data[i] = p1;
+	}
+}

--- a/qt/tileedit/tileedit/imagetools.h
+++ b/qt/tileedit/tileedit/imagetools.h
@@ -1,0 +1,20 @@
+#ifndef IMAGETOOLS_H
+#define IMAGETOOLS_H
+
+#include <vector>
+#include <windows.h>
+
+struct Image {
+	std::vector<DWORD> data;
+	DWORD width;
+	DWORD height;
+
+	Image() { width = height = 0; }
+	Image &operator=(const Image &img);
+	Image SubImage(const std::pair<DWORD, DWORD> &xrange, const std::pair<DWORD, DWORD> &yrange);
+};
+
+void match_histogram(Image &im1, const Image &im2);
+void match_hue_sat(Image &im1, const Image &im2);
+
+#endif // !IMAGETOOLS_H

--- a/qt/tileedit/tileedit/tile.cpp
+++ b/qt/tileedit/tileedit/tile.cpp
@@ -188,6 +188,53 @@ void SurfTile::Save()
 	SaveDXT1();
 }
 
+bool SurfTile::mapToAncestors(int minlvl) const
+{
+	if (m_lvl <= 4 || m_lvl <= minlvl)
+		return false;
+
+	int lvl = m_lvl - 1;
+	int ilat = m_ilat / 2;
+	int ilng = m_ilng / 2;
+
+	SurfTile *stile = SurfTile::Load(lvl, ilat, ilng);
+	if (!stile)
+		return false;
+
+	Image &idata = stile->getData();
+	const int szh = TILE_SURFSTRIDE / 2;
+	int xofs = (m_ilng & 1 ? szh : 0);
+	int yofs = (m_ilat & 1 ? szh : 0);
+	bool isModified = false;
+
+	for (int y = 0; y < szh; y++) {
+		for (int x = 0; x < szh; x++) {
+			DWORD p1 = m_idata.data[x * 2 + y * 2 * TILE_SURFSTRIDE];
+			DWORD p2 = m_idata.data[x * 2 + 1 + y * 2 * TILE_SURFSTRIDE];
+			DWORD p3 = m_idata.data[x * 2 + (y * 2 + 1) * TILE_SURFSTRIDE];
+			DWORD p4 = m_idata.data[x * 2 + 1 + (y * 2 + 1) * TILE_SURFSTRIDE];
+
+			DWORD c1 = ((DWORD)(p1 & 0xff) + (DWORD)(p2 & 0xff) + (DWORD)(p3 & 0xff) + (DWORD)(p4 & 0xff)) >> 2;
+			DWORD c2 = ((DWORD)((p1 >> 8) & 0xff) + (DWORD)((p2 >> 8) & 0xff) + (DWORD)((p3 >> 8) & 0xff) + (DWORD)((p4 >> 8) & 0xff)) >> 2;
+			DWORD c3 = ((DWORD)((p1 >> 16) & 0xff) + (DWORD)((p2 >> 16) & 0xff) + (DWORD)((p3 >> 16) & 0xff) + (DWORD)((p4 >> 16) & 0xff)) >> 2;
+
+			DWORD v = 0xff000000 | c1 | (c2 << 8) | (c3 << 16);
+			if (v != idata.data[xofs + x + (yofs + y) * TILE_SURFSTRIDE]) {
+				idata.data[xofs + x + (yofs + y)*TILE_SURFSTRIDE] = v;
+				isModified = true;
+			}
+		}
+	}
+
+	if (isModified) {
+		stile->Save();
+		stile->mapToAncestors(minlvl);
+	}
+	delete stile;
+	return isModified;
+}
+
+
 void SurfTile::setTreeMgr(const ZTreeMgr *treeMgr)
 {
 	s_treeMgr = treeMgr;

--- a/qt/tileedit/tileedit/tile.h
+++ b/qt/tileedit/tileedit/tile.h
@@ -52,6 +52,8 @@ public:
 	static void setOpenMode(int mode);
 	static void setQueryAncestor(bool query);
 
+	virtual bool mapToAncestors(int minlvl) const { return false; }
+
 protected:
 	void ensureLayerDir();
 
@@ -95,6 +97,7 @@ public:
 	void Save();
 	static void setTreeMgr(const ZTreeMgr *mgr);
 	const std::string Layer() const { return std::string("Surf"); }
+	bool mapToAncestors(int minlvl) const;
 
 protected:
 	static const ZTreeMgr *s_treeMgr;

--- a/qt/tileedit/tileedit/tile.h
+++ b/qt/tileedit/tileedit/tile.h
@@ -6,6 +6,8 @@
 #include "ddsread.h"
 #include "ZTreeMgr.h"
 
+#define TILE_SURFSTRIDE 512
+
 enum TileMode {
 	TILEMODE_NONE,
 	TILEMODE_SURFACE,
@@ -17,6 +19,9 @@ enum TileMode {
 
 inline int nLat(int lvl) { return (lvl < 4 ? 1 : 1 << (lvl - 4)); }
 inline int nLng(int lvl) { return (lvl < 4 ? 1 : 1 << (lvl - 3)); }
+
+void ensureLayerDir(const char *rootDir, const char *layer, int lvl, int ilat);
+
 
 class Tile
 {
@@ -48,6 +53,8 @@ public:
 	static void setQueryAncestor(bool query);
 
 protected:
+	void ensureLayerDir();
+
     int m_lvl;
     int m_ilat;
     int m_ilng;
@@ -68,10 +75,12 @@ public:
 	DXT1Tile(int lvl, int ilat, int ilng);
 	DXT1Tile(const DXT1Tile &tile);
 	virtual void set(const Tile *tile);
+	Image &getData() { return m_idata; }
 	const Image &getData() const { return m_idata; }
 
 protected:
 	virtual void LoadDXT1(const ZTreeMgr *mgr = 0);
+	void SaveDXT1();
 	void LoadSubset(DXT1Tile *tile, const ZTreeMgr *mgr = 0);
 	void LoadImage(Image &im, int lvl, int ilat, int ilng, const ZTreeMgr *mgr);
 
@@ -81,12 +90,13 @@ protected:
 class SurfTile: public DXT1Tile
 {
 public:
-    static SurfTile *Load(int lvl, int ilat, int ilng);
+	SurfTile(int lvl, int ilat, int ilng);
+	static SurfTile *Load(int lvl, int ilat, int ilng);
+	void Save();
 	static void setTreeMgr(const ZTreeMgr *mgr);
 	const std::string Layer() const { return std::string("Surf"); }
 
 protected:
-    SurfTile(int lvl, int ilat, int ilng);
 	static const ZTreeMgr *s_treeMgr;
 };
 

--- a/qt/tileedit/tileedit/tileblock.cpp
+++ b/qt/tileedit/tileedit/tileblock.cpp
@@ -88,6 +88,18 @@ bool TileBlock::hasAncestorData() const
 	return false;
 }
 
+bool TileBlock::mapToAncestors(int minlvl) const
+{
+	bool isModified = false;
+	for (int ilat = m_ilat0; ilat < m_ilat1; ilat++) {
+		for (int ilng = m_ilng0; ilng < m_ilng1; ilng++) {
+			const Tile *tile = getTile(ilat, ilng);
+			isModified = tile->mapToAncestors(minlvl) || isModified;
+		}
+	}
+	return isModified;
+}
+
 
 DXT1TileBlock::DXT1TileBlock(int lvl, int ilat0, int ilat1, int ilng0, int ilng1)
 	: TileBlock(lvl, ilat0, ilat1, ilng0, ilng1)
@@ -600,18 +612,6 @@ void ElevTileBlock::MatchNeighbourTiles()
 			}
 		}
 	}
-}
-
-bool ElevTileBlock::MatchParentTiles(int minlvl) const
-{
-	bool isModified = false;
-	for (int ilat = m_ilat0; ilat < m_ilat1; ilat++) {
-		for (int ilng = m_ilng0; ilng < m_ilng1; ilng++) {
-			const ElevTile *etile = (const ElevTile*)getTile(ilat, ilng);
-			isModified = isModified || etile->MatchParentTile(minlvl);
-		}
-	}
-	return isModified;
 }
 
 void ElevTileBlock::setWaterMask(const MaskTileBlock *mtileblock)

--- a/qt/tileedit/tileedit/tileblock.cpp
+++ b/qt/tileedit/tileedit/tileblock.cpp
@@ -131,6 +131,8 @@ bool SurfTileBlock::copyTile(int ilat, int ilng, Tile *tile) const
 
 void SurfTileBlock::syncTile(int ilat, int ilng)
 {
+	int tilesize = (m_lvl == 1 ? 128 : m_lvl == 2 ? 256 : TILE_SURFSTRIDE);
+
 	if (ilat < m_ilat0 || ilat >= m_ilat1) return;
 	if (ilng < m_ilng0 || ilng >= m_ilng1) return;
 
@@ -145,20 +147,20 @@ void SurfTileBlock::syncTile(int ilat, int ilng)
 		m_tile[idx] = stile;
 	}
 	Image &idata = stile->getData();
-	if (idata.width < TILE_SURFSTRIDE || idata.height < TILE_SURFSTRIDE) {
-		idata.width = idata.height = TILE_SURFSTRIDE;
+	if (idata.width != tilesize || idata.height != tilesize) {
+		idata.width = idata.height = tilesize;
 		idata.data.resize(idata.width * idata.height);
 	}
 
 	int xblock = ilng - m_ilng0;
 	int yblock = m_ilat1 - 1 - ilat;
 
-	int block_x0 = xblock * TILE_SURFSTRIDE;
-	int block_y0 = yblock * TILE_SURFSTRIDE;
+	int block_x0 = xblock * tilesize;
+	int block_y0 = yblock * tilesize;
 
-	for (int y = 0; y < TILE_SURFSTRIDE; y++) {
-		for (int x = 0; x < TILE_SURFSTRIDE; x++) {
-			stile->getData().data[y*TILE_SURFSTRIDE + x] =
+	for (int y = 0; y < tilesize; y++) {
+		for (int x = 0; x < tilesize; x++) {
+			stile->getData().data[y*tilesize + x] =
 				m_idata.data[(block_y0 + y) * m_idata.width + (block_x0 + x)];
 		}
 	}
@@ -166,7 +168,7 @@ void SurfTileBlock::syncTile(int ilat, int ilng)
 
 SurfTileBlock *SurfTileBlock::Load(int lvl, int ilat0, int ilat1, int ilng0, int ilng1)
 {
-	const int tilesize = 512;
+	int tilesize = (lvl == 1 ? 128 : lvl == 2 ? 256 : TILE_SURFSTRIDE);
 
 	SurfTileBlock *stileblock = new SurfTileBlock(lvl, ilat0, ilat1, ilng0, ilng1);
 

--- a/qt/tileedit/tileedit/tileblock.h
+++ b/qt/tileedit/tileedit/tileblock.h
@@ -18,6 +18,7 @@ public:
 	int iLng1() const { return m_ilng1; }
 	int nLat() const { return (m_lvl < 4 ? 1 : 1 << (m_lvl - 4)); }
 	int nLng() const { return (m_lvl < 4 ? 1 : 1 << (m_lvl - 3)); }
+	int iLng_norm(int ilng) const { int ilngn = ilng; int nlng = nLng(); while (ilngn < 0) ilngn += nlng; while (ilngn >= nlng) ilngn -= nlng; return ilngn; }
 	int nLatBlock() const { return m_nblocklat; }
 	int nLngBlock() const { return m_nblocklng; }
 	int nBlock() const { return m_nblocklat * m_nblocklng; }
@@ -50,6 +51,18 @@ public:
 	virtual bool copyTile(int ilat, int ilng, Tile *tile) const = 0;
 
 	/**
+	* \brief Map edits to the tileblock back to one of the individual tiles
+	*/
+	virtual void syncTile(int ilat, int ilng) {};
+
+	/**
+	* \brief Map edits to the tileblock back to the individual tiles
+	*
+	* This must be called before calling Save() or SaveMod() to make sure the tiles are up to date.
+	*/
+	void syncTiles();
+
+	/**
 	 * \brief Returns true if at least one of the tiles has been synthesized from an ancestor
 	 */
 	bool hasAncestorData() const;
@@ -72,6 +85,7 @@ public:
 	virtual void ExtractImage(Image &img, TileMode mode, int exmin = -1, int exmax = -1, int eymin = -1, int eymax = -1) const
 	{ img = m_idata; }
 	const Image &getData() const { return m_idata; }
+	Image &getData() { return m_idata; }
 
 protected:
 	Image m_idata;
@@ -84,6 +98,7 @@ public:
 	static SurfTileBlock *Load(int lvl, int ilat0, int ilat1, int ilng0, int ilng1);
 	virtual Tile *copyTile(int ilat, int ilng) const;
 	virtual bool copyTile(int ilat, int ilng, Tile *tile) const;
+	virtual void syncTile(int ilat, int ilng);
 
 protected:
 	SurfTileBlock(int lvl, int ilat0, int ilat1, int ilng0, int ilng1);
@@ -126,16 +141,9 @@ public:
 	void RescanLimits();
 
 	/**
-	 * \brief Map edits to the tileblock back to the individual tiles
-	 *
-	 * This must be called before calling Save() or SaveMod() to make sure the tiles are up to date.
-	 */
-	void SyncTiles();
-
-	/**
 	 * \brief Map edits to the tileblock back to one of the individual tiles
 	 */
-	void SyncTile(int ilat, int ilng);
+	void syncTile(int ilat, int ilng);
 
 	/**
 	* \brief Propagate edits in the boundary overlap zones to the neighbour tiles

--- a/qt/tileedit/tileedit/tileblock.h
+++ b/qt/tileedit/tileedit/tileblock.h
@@ -67,6 +67,13 @@ public:
 	 */
 	bool hasAncestorData() const;
 
+	/**
+	* \brief Recursively map edits to parents down to level minlvl
+	*
+	* Requires SyncTiles to have been called.
+	*/
+	bool mapToAncestors(int minlvl) const;
+
 protected:
 
 	int m_lvl;
@@ -149,13 +156,6 @@ public:
 	* \brief Propagate edits in the boundary overlap zones to the neighbour tiles
 	*/
 	void MatchNeighbourTiles();
-
-	/**
-	 * \brief Recursively map edits to parents down to level minlvl
-	 *
-	 * Requires SyncTiles to have been called.
-	 */
-	bool MatchParentTiles(int minlvl) const;
 
 	void ExtractImage(Image &img, TileMode mode, int exmin = -1, int exmax = -1, int eymin = -1, int eymax = -1) const;
 

--- a/qt/tileedit/tileedit/tileedit.cpp
+++ b/qt/tileedit/tileedit/tileedit.cpp
@@ -861,7 +861,7 @@ void tileedit::setTile(int lvl, int ilat, int ilng)
 		m_eTileBlock->syncTiles();
 		m_eTileBlock->MatchNeighbourTiles();
 		m_eTileBlock->SaveMod();
-		m_eTileBlock->MatchParentTiles(m_eTileBlock->Level() - 5);
+		m_eTileBlock->mapToAncestors(m_eTileBlock->Level() - 5);
 	}
 
 	m_lvl = lvl;

--- a/qt/tileedit/tileedit/tileedit.cpp
+++ b/qt/tileedit/tileedit/tileedit.cpp
@@ -3,6 +3,7 @@
 #include "tile.h"
 #include "elevtile.h"
 #include "tileblock.h"
+#include "dlgsurfimport.h"
 #include "dlgconfig.h"
 #include "dlgelevconfig.h"
 #include "dlgelevexport.h"
@@ -143,6 +144,8 @@ tileedit::~tileedit()
 
 void tileedit::createMenus()
 {
+	QMenu *menu;
+
     fileMenu = ui->menuBar->addMenu(tr("&File"));
     fileMenu->addAction(openAct);
 	fileMenu->addSeparator();
@@ -150,11 +153,14 @@ void tileedit::createMenus()
 	fileMenu->addSeparator();
 	fileMenu->addAction(actionExit);
 
-	QMenu *menu = ui->menuBar->addMenu(tr("&Elevation"));
+	menu = ui->menuBar->addMenu(tr("&Surface"));
+	menu->addAction(actionSurfImport);
+
+	menu = ui->menuBar->addMenu(tr("&Elevation"));
 	menu->addAction(actionElevConfig);
 	menu->addSeparator();
-	menu->addAction(actionExportImage);
-	menu->addAction(actionImportImage);
+	menu->addAction(actionElevExport);
+	menu->addAction(actionElevImport);
 }
 
 void tileedit::createActions()
@@ -168,15 +174,18 @@ void tileedit::createActions()
 	actionExit = new QAction(tr("E&xit"), this);
 	connect(actionExit, &QAction::triggered, this, &tileedit::on_actionExit_triggered);
 
+	actionSurfImport = new QAction(tr("&Import from image"), this);
+	connect(actionSurfImport, &QAction::triggered, this, &tileedit::onSurfImportImage);
+
 	actionElevConfig = new QAction(tr("&Configure"), this);
 	actionElevConfig->setCheckable(true);
 	connect(actionElevConfig, &QAction::triggered, this, &tileedit::onElevConfig);
 
-	actionExportImage = new QAction(tr("&Export to image"), this);
-	connect(actionExportImage, &QAction::triggered, this, &tileedit::onElevExportImage);
+	actionElevExport = new QAction(tr("&Export to image"), this);
+	connect(actionElevExport, &QAction::triggered, this, &tileedit::onElevExportImage);
 
-	actionImportImage = new QAction(tr("&Import from image"), this);
-	connect(actionImportImage, &QAction::triggered, this, &tileedit::onElevImportImage);
+	actionElevImport = new QAction(tr("&Import from image"), this);
+	connect(actionElevImport, &QAction::triggered, this, &tileedit::onElevImportImage);
 }
 
 void tileedit::elevDisplayParamChanged()
@@ -304,6 +313,14 @@ void tileedit::onElevExportImage()
 
 	DlgElevExport dlg(this);
 	dlg.exec();
+}
+
+void tileedit::onSurfImportImage()
+{
+	DlgSurfImport dlg(this);
+	if (dlg.exec() == QDialog::Accepted) {
+		loadTile(m_lvl, m_ilat, m_ilng); // refresh
+	}
 }
 
 void tileedit::onElevImportImage()
@@ -587,12 +604,15 @@ void tileedit::OnMouseMovedInCanvas(int canvasIdx, QMouseEvent *event)
 		else {
 			sprintf(cbuf, "X=%d/%d, Y=%d/%d", mpx, iw, mpy, ih);
 			ui->labelData2->setText(cbuf);
-			DWORD col = img.data[mpx + mpy*img.width];
-			if (m_panel[canvasIdx].layerType->currentIndex() == 1) {
-				ui->labelData3->setText(col & 0xFF000000 ? "Diffuse (Land)" : "Specular (Water)");
-			} else {
-				sprintf(cbuf, "R=%d, G=%d, B=%d", (col >> 0x10) & 0xFF, (col >> 0x08) & 0xFF, col & 0xFF);
-				ui->labelData3->setText(cbuf);
+			if (mpx >= 0 && mpx < img.width && mpy >= 0 && mpy < img.height) {
+				DWORD col = img.data[mpx + mpy*img.width];
+				if (m_panel[canvasIdx].layerType->currentIndex() == 1) {
+					ui->labelData3->setText(col & 0xFF000000 ? "Diffuse (Land)" : "Specular (Water)");
+				}
+				else {
+					sprintf(cbuf, "R=%d, G=%d, B=%d", (col >> 0x10) & 0xFF, (col >> 0x08) & 0xFF, col & 0xFF);
+					ui->labelData3->setText(cbuf);
+				}
 			}
 		}
 		for (int i = 0; i < 3; i++) {
@@ -604,13 +624,17 @@ void tileedit::OnMouseMovedInCanvas(int canvasIdx, QMouseEvent *event)
 			}
 			else if (m_panel[i].layerType->currentIndex() == 0 || m_panel[i].layerType->currentIndex() == 2) {
 				const Image &img = m_panel[i].canvas->getImage();
-				DWORD col = img.data[mpx + mpy*img.width];
-				m_panel[i].colorbar->setRGBValue((col >> 0x10) & 0xFF, (col >> 0x08) & 0xFF, col & 0xFF);
+				if (mpx >= 0 && mpx < img.width && mpy >= 0 && mpy < img.height) {
+					DWORD col = img.data[mpx + mpy*img.width];
+					m_panel[i].colorbar->setRGBValue((col >> 0x10) & 0xFF, (col >> 0x08) & 0xFF, col & 0xFF);
+				}
 			}
 			else if (m_panel[i].layerType->currentIndex() == 1) {
 				const Image &img = m_panel[i].canvas->getImage();
-				bool isWater = (img.data[mpx + mpy*img.width] & 0xFF000000) == 0;
-				m_panel[i].colorbar->setScalarValue(isWater ? 0.0 : 1.0);
+				if (mpx >= 0 && mpx < img.width && mpy >= 0 && mpy < img.height) {
+					bool isWater = (img.data[mpx + mpy*img.width] & 0xFF000000) == 0;
+					m_panel[i].colorbar->setScalarValue(isWater ? 0.0 : 1.0);
+				}
 			}
 		}
 	}
@@ -834,7 +858,7 @@ void tileedit::setToolOptions()
 void tileedit::setTile(int lvl, int ilat, int ilng)
 {
 	if (m_eTileBlock && m_eTileBlock->isModified()) {
-		m_eTileBlock->SyncTiles();
+		m_eTileBlock->syncTiles();
 		m_eTileBlock->MatchNeighbourTiles();
 		m_eTileBlock->SaveMod();
 		m_eTileBlock->MatchParentTiles(m_eTileBlock->Level() - 5);

--- a/qt/tileedit/tileedit/tileedit.h
+++ b/qt/tileedit/tileedit/tileedit.h
@@ -69,6 +69,7 @@ private slots:
     void openDir();
 	void on_actionExit_triggered();
 	void on_actionConfig_triggered();
+	void onSurfImportImage();
 	void onElevConfig();
 	void onElevExportImage();
 	void onElevImportImage();
@@ -95,9 +96,10 @@ private:
     QAction *openAct;
 	QAction *actionConfig;
 	QAction *actionExit;
+	QAction *actionSurfImport;
 	QAction *actionElevConfig;
-	QAction *actionExportImage;
-	QAction *actionImportImage;
+	QAction *actionElevExport;
+	QAction *actionElevImport;
 
     QLabel *status;
 

--- a/qt/tileedit/tileedit/tileedit.vcxproj
+++ b/qt/tileedit/tileedit/tileedit.vcxproj
@@ -174,6 +174,8 @@
     <ClCompile Include="dlgelevconfig.cpp" />
     <ClCompile Include="dlgelevexport.cpp" />
     <ClCompile Include="dlgelevimport.cpp" />
+    <ClCompile Include="dlgsurfimport.cpp" />
+    <ClCompile Include="dxt_io.cpp" />
     <ClCompile Include="elevtile.cpp" />
     <ClCompile Include="elv_io.cpp" />
     <ClCompile Include="main.cpp" />
@@ -191,6 +193,7 @@
     <QtUic Include="dlgElevConfig.ui" />
     <QtUic Include="dlgElevExport.ui" />
     <QtUic Include="dlgElevImport.ui" />
+    <QtUic Include="dlgSurfImport.ui" />
     <QtUic Include="tileedit.ui" />
   </ItemGroup>
   <ItemGroup>
@@ -213,6 +216,12 @@
       <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles;.;$(QTDIR)\include;.\GeneratedFiles\$(ConfigurationName);$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtANGLE;$(QTDIR)\include\QtWidgets;$(LibpngIncludeDir);$(ZlibIncludeDir)</IncludePath>
       <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release_static|x64'">.\GeneratedFiles;.;$(QTDIR)\include;.\GeneratedFiles\$(ConfigurationName);$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtANGLE;$(QTDIR)\include\QtWidgets;$(LibpngIncludeDir);$(ZlibIncludeDir)</IncludePath>
     </QtMoc>
+    <QtMoc Include="dlgsurfimport.h">
+      <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles;.;$(QTDIR)\include;.\GeneratedFiles\$(ConfigurationName);$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtANGLE;$(QTDIR)\include\QtWidgets;$(FastdxtIncludeDir);$(LibpngIncludeDir);$(ZlibIncludeDir)</IncludePath>
+      <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles;.;$(QTDIR)\include;.\GeneratedFiles\$(ConfigurationName);$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtANGLE;$(QTDIR)\include\QtWidgets;$(FastdxtIncludeDir);$(LibpngIncludeDir);$(ZlibIncludeDir)</IncludePath>
+      <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release_static|x64'">.\GeneratedFiles;.;$(QTDIR)\include;.\GeneratedFiles\$(ConfigurationName);$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtANGLE;$(QTDIR)\include\QtWidgets;$(FastdxtIncludeDir);$(LibpngIncludeDir);$(ZlibIncludeDir)</IncludePath>
+    </QtMoc>
+    <ClInclude Include="dxt_io.h" />
     <ClInclude Include="ZTreeMgr.h" />
     <QtMoc Include="colorbar.h">
       <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles;.;$(QTDIR)\include;.\GeneratedFiles\$(ConfigurationName);$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtANGLE;$(QTDIR)\include\QtWidgets</IncludePath>

--- a/qt/tileedit/tileedit/tileedit.vcxproj
+++ b/qt/tileedit/tileedit/tileedit.vcxproj
@@ -178,6 +178,7 @@
     <ClCompile Include="dxt_io.cpp" />
     <ClCompile Include="elevtile.cpp" />
     <ClCompile Include="elv_io.cpp" />
+    <ClCompile Include="imagetools.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="tile.cpp" />
     <ClCompile Include="tileblock.cpp" />
@@ -222,6 +223,7 @@
       <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release_static|x64'">.\GeneratedFiles;.;$(QTDIR)\include;.\GeneratedFiles\$(ConfigurationName);$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtANGLE;$(QTDIR)\include\QtWidgets;$(FastdxtIncludeDir);$(LibpngIncludeDir);$(ZlibIncludeDir)</IncludePath>
     </QtMoc>
     <ClInclude Include="dxt_io.h" />
+    <ClInclude Include="imagetools.h" />
     <ClInclude Include="ZTreeMgr.h" />
     <QtMoc Include="colorbar.h">
       <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles;.;$(QTDIR)\include;.\GeneratedFiles\$(ConfigurationName);$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtANGLE;$(QTDIR)\include\QtWidgets</IncludePath>

--- a/qt/tileedit/tileedit/tileedit.vcxproj
+++ b/qt/tileedit/tileedit/tileedit.vcxproj
@@ -56,16 +56,19 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\zlib.props" />
     <Import Project="..\libpng.props" />
+    <Import Project="..\fastdxt.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\zlib.props" />
     <Import Project="..\libpng.props" />
+    <Import Project="..\fastdxt.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_static|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\zlib.props" />
     <Import Project="..\libpng.props" />
+    <Import Project="..\fastdxt.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/qt/tileedit/tileedit/tileedit.vcxproj.filters
+++ b/qt/tileedit/tileedit/tileedit.vcxproj.filters
@@ -75,6 +75,12 @@
     <ClCompile Include="dlgelevimport.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="dlgsurfimport.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="dxt_io.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="tileedit.h">
@@ -98,6 +104,9 @@
     <QtMoc Include="dlgelevimport.h">
       <Filter>Header Files</Filter>
     </QtMoc>
+    <QtMoc Include="dlgsurfimport.h">
+      <Filter>Header Files</Filter>
+    </QtMoc>
   </ItemGroup>
   <ItemGroup>
     <QtUic Include="tileedit.ui">
@@ -113,6 +122,9 @@
       <Filter>Form Files</Filter>
     </QtUic>
     <QtUic Include="dlgElevImport.ui">
+      <Filter>Form Files</Filter>
+    </QtUic>
+    <QtUic Include="dlgSurfImport.ui">
       <Filter>Form Files</Filter>
     </QtUic>
   </ItemGroup>
@@ -144,6 +156,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ZTreeMgr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="dxt_io.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/qt/tileedit/tileedit/tileedit.vcxproj.filters
+++ b/qt/tileedit/tileedit/tileedit.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="dxt_io.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="imagetools.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="tileedit.h">
@@ -159,6 +162,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="dxt_io.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="imagetools.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Closes #24:

- a surface patch can now be imported from a PNG image and the corresponding tiles written out in DXT1 format.
- edits can be automatically propagated down to lower resolution tiles
- the PNG alpha channel can be used to blend the imported patch with the existing background
- colour matching options (cumulative histogram and hue+saturation) are provided