### PR TITLE
#27: surface patch ancestor propagation

### DIFF
--- a/qt/tileedit/tileedit/dlgsurfimport.cpp
+++ b/qt/tileedit/tileedit/dlgsurfimport.cpp
@@ -19,11 +19,9 @@ DlgSurfImport::DlgSurfImport(tileedit *parent)
 	connect(ui->radioParamFromUser, SIGNAL(clicked()), this, SLOT(onParamFromUser()));
 	connect(ui->editMetaPath, SIGNAL(textChanged(const QString&)), this, SLOT(onMetaFileChanged(const QString&)));
 	connect(ui->spinLvl, SIGNAL(valueChanged(int)), this, SLOT(onLvl(int)));
-	connect(ui->checkPropagateChanges, SIGNAL(stateChanged(int)), this, SLOT(onPropagateChanges(int)));
 
 	m_pathEdited = m_metaEdited = false;
 	m_haveMeta = false;
-	m_propagationLevel = ui->spinPropagationLevel->value();
 	memset(&m_metaInfo, 0, sizeof(SurfPatchMetaInfo));
 }
 
@@ -100,12 +98,6 @@ void DlgSurfImport::onLvl(int val)
 	ui->spinIlng1->setMaximum(nlng - 1);
 }
 
-void DlgSurfImport::onPropagateChanges(int state)
-{
-	m_propagationLevel = (state == Qt::Checked ? ui->spinPropagationLevel->value() : 0);
-	ui->widgetPropagateChanges->setEnabled(state == Qt::Checked);
-}
-
 void DlgSurfImport::accept()
 {
 	if (ui->radioParamFromUser->isChecked()) {
@@ -156,9 +148,8 @@ void DlgSurfImport::accept()
 				stile->Save();
 			// ...
 		}
-	if (m_propagationLevel) {
-		sblock->mapToAncestors(m_propagationLevel);
-	}
+	if (ui->checkPropagateChanges->isChecked())
+		sblock->mapToAncestors(ui->spinPropagationLevel->value());
 	
 	QDialog::accept();
 }

--- a/qt/tileedit/tileedit/dlgsurfimport.h
+++ b/qt/tileedit/tileedit/dlgsurfimport.h
@@ -24,7 +24,6 @@ public slots:
 	void onParamFromUser();
 	void onMetaFileChanged(const QString&);
 	void onLvl(int);
-	void onPropagateChanges(int);
 	void accept();
 
 protected:
@@ -36,7 +35,6 @@ private:
 	SurfPatchMetaInfo m_metaInfo;
 	bool m_pathEdited, m_metaEdited;
 	bool m_haveMeta;
-	int m_propagationLevel;
 };
 
 #endif // !DLGSURFIMPORT_H


### PR DESCRIPTION
Closes #27:
surface patch import: user selection for ancestor propagation is now correctly applied.