### PR TITLE
#29: Create required non-existent surface tiles on patch import

### DIFF
--- a/qt/tileedit/tileedit/dlgSurfImport.ui
+++ b/qt/tileedit/tileedit/dlgSurfImport.ui
@@ -18,7 +18,7 @@
     <rect>
      <x>20</x>
      <y>490</y>
-     <width>351</width>
+     <width>361</width>
      <height>33</height>
     </rect>
    </property>
@@ -304,6 +304,9 @@
     </item>
     <item>
      <widget class="QWidget" name="widgetPropagateChanges" native="true">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <property name="leftMargin">
         <number>20</number>

--- a/qt/tileedit/tileedit/dlgsurfimport.cpp
+++ b/qt/tileedit/tileedit/dlgsurfimport.cpp
@@ -144,9 +144,7 @@ void DlgSurfImport::accept()
 		for (int ilng = m_metaInfo.ilng0; ilng < m_metaInfo.ilng1; ilng++) {
 			sblock->syncTile(ilat, ilng);
 			SurfTile *stile = (SurfTile*)sblock->_getTile(ilat, ilng);
-			if (stile->Level() == stile->subLevel())
-				stile->Save();
-			// ...
+			stile->Save();
 		}
 	if (ui->checkPropagateChanges->isChecked())
 		sblock->mapToAncestors(ui->spinPropagationLevel->value());

--- a/qt/tileedit/tileedit/dlgsurfimport.cpp
+++ b/qt/tileedit/tileedit/dlgsurfimport.cpp
@@ -19,7 +19,7 @@ DlgSurfImport::DlgSurfImport(tileedit *parent)
 	connect(ui->radioParamFromUser, SIGNAL(clicked()), this, SLOT(onParamFromUser()));
 	connect(ui->editMetaPath, SIGNAL(textChanged(const QString&)), this, SLOT(onMetaFileChanged(const QString&)));
 	connect(ui->spinLvl, SIGNAL(valueChanged(int)), this, SLOT(onLvl(int)));
-
+	connect(ui->checkPropagateChanges, SIGNAL(stateChanged(int)), this, SLOT(onPropagateChanges(int)));
 	m_pathEdited = m_metaEdited = false;
 	m_haveMeta = false;
 	memset(&m_metaInfo, 0, sizeof(SurfPatchMetaInfo));
@@ -96,6 +96,11 @@ void DlgSurfImport::onLvl(int val)
 	ui->spinIlat1->setMaximum(nlat - 1);
 	ui->spinIlng0->setMaximum(nlng - 1);
 	ui->spinIlng1->setMaximum(nlng - 1);
+}
+
+void DlgSurfImport::onPropagateChanges(int state)
+{
+	ui->widgetPropagateChanges->setEnabled(state == Qt::Checked);
 }
 
 void DlgSurfImport::accept()

--- a/qt/tileedit/tileedit/dlgsurfimport.h
+++ b/qt/tileedit/tileedit/dlgsurfimport.h
@@ -24,6 +24,7 @@ public slots:
 	void onParamFromUser();
 	void onMetaFileChanged(const QString&);
 	void onLvl(int);
+	void onPropagateChanges(int);
 	void accept();
 
 protected:

--- a/qt/tileedit/tileedit/elevtile.h
+++ b/qt/tileedit/tileedit/elevtile.h
@@ -40,6 +40,7 @@ struct ElevDisplayParam {
 
 
 class ElevTile : public Tile {
+	friend class TileBlock;
 	friend class ElevTileBlock;
 
 public:
@@ -66,7 +67,7 @@ public:
 	/**
 	 * \brief Interpolate the tile to the next resolution level
 	 */
-	ElevTileBlock Prolong();
+	TileBlock *ProlongToChildren() const;
 
 	void setWaterMask(const MaskTile *mtile);
 

--- a/qt/tileedit/tileedit/tile.h
+++ b/qt/tileedit/tileedit/tile.h
@@ -73,6 +73,8 @@ protected:
 
 class DXT1Tile: public Tile
 {
+	friend class TileBlock;
+
 public:
 	DXT1Tile(int lvl, int ilat, int ilng);
 	DXT1Tile(const DXT1Tile &tile);
@@ -81,10 +83,11 @@ public:
 	const Image &getData() const { return m_idata; }
 
 protected:
-	virtual void LoadDXT1(const ZTreeMgr *mgr = 0);
 	void SaveDXT1();
-	void LoadSubset(DXT1Tile *tile, const ZTreeMgr *mgr = 0);
-	void LoadImage(Image &im, int lvl, int ilat, int ilng, const ZTreeMgr *mgr);
+	bool LoadDXT1(const ZTreeMgr *mgr = 0, bool directOnly = false);
+	void LoadSubset(const ZTreeMgr *mgr = 0);
+	void LoadData(Image &im, int lvl, int ilat, int ilng, const ZTreeMgr *mgr);
+	TileBlock *ProlongToChildren() const;
 
 	Image m_idata;
 };
@@ -94,12 +97,14 @@ class SurfTile: public DXT1Tile
 public:
 	SurfTile(int lvl, int ilat, int ilng);
 	static SurfTile *Load(int lvl, int ilat, int ilng);
+	static SurfTile *InterpolateFromAncestor(int lvl, int ilat, int ilng);
 	void Save();
 	static void setTreeMgr(const ZTreeMgr *mgr);
 	const std::string Layer() const { return std::string("Surf"); }
 	bool mapToAncestors(int minlvl) const;
-
+	
 protected:
+	bool InterpolateFromAncestor();
 	static const ZTreeMgr *s_treeMgr;
 };
 

--- a/qt/tileedit/tileedit/tileblock.cpp
+++ b/qt/tileedit/tileedit/tileblock.cpp
@@ -104,6 +104,9 @@ bool TileBlock::mapToAncestors(int minlvl) const
 DXT1TileBlock::DXT1TileBlock(int lvl, int ilat0, int ilat1, int ilng0, int ilng1)
 	: TileBlock(lvl, ilat0, ilat1, ilng0, ilng1)
 {
+	m_idata.width = (ilng1 - ilng0) * TILE_SURFSTRIDE;
+	m_idata.height = (ilat1 - ilat0) * TILE_SURFSTRIDE;
+	m_idata.data.resize(m_idata.width * m_idata.height);
 }
 
 
@@ -165,7 +168,7 @@ void SurfTileBlock::syncTile(int ilat, int ilng)
 	}
 
 	int xblock = ilng - m_ilng0;
-	int yblock = m_ilat1 - 1 - ilat;
+	int yblock = ilat - m_ilat0;
 
 	int block_x0 = xblock * tilesize;
 	int block_y0 = yblock * tilesize;

--- a/qt/tileedit/tileedit/tileblock.h
+++ b/qt/tileedit/tileedit/tileblock.h
@@ -103,12 +103,10 @@ class SurfTileBlock : public DXT1TileBlock
 {
 public:
 	static SurfTileBlock *Load(int lvl, int ilat0, int ilat1, int ilng0, int ilng1);
+	SurfTileBlock(int lvl, int ilat0, int ilat1, int ilng0, int ilng1);
 	virtual Tile *copyTile(int ilat, int ilng) const;
 	virtual bool copyTile(int ilat, int ilng, Tile *tile) const;
 	virtual void syncTile(int ilat, int ilng);
-
-protected:
-	SurfTileBlock(int lvl, int ilat0, int ilat1, int ilng0, int ilng1);
 };
 
 


### PR DESCRIPTION
Closes #29:

Importing surface tiles not represented in the quadtree now generates the required tiles. If propagation to ancestors is requested, any missing ancestor tiles are generated as well.